### PR TITLE
Feature/4/heroku setup

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -20,6 +20,7 @@ django-dotenv = "*"
 pyyaml = "==4.2b1"
 django-model-utils = "*"
 faker = "*"
+django-heroku = "*"
 
 [requires]
 python_version = "3"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c45ff748f432f15aa699329d600bd74d58002b218acc2aa8edd2b3cca2fc1fc3"
+            "sha256": "bf2d636f9f5755b0ed884af69e495779238432e85e46aa74bea2f2cb7e1e7462"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,11 @@
         },
         "arrow": {
             "hashes": [
-                "sha256:9cb4a910256ed536751cd5728673bfb53e6f0026e240466f90c2a92c0b79c895"
+                "sha256:3397e5448952e18e1295bf047014659effa5ae8da6a5371d37ff0ddc46fa6872",
+                "sha256:6f54d9f016c0b7811fac9fb8c2c7fa7421d80c54dbdd75ffb12913c55db60b8a"
             ],
             "index": "pypi",
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "attrs": {
             "hashes": [
@@ -52,13 +53,20 @@
             ],
             "version": "==7.0"
         },
+        "dj-database-url": {
+            "hashes": [
+                "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163",
+                "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"
+            ],
+            "version": "==0.5.0"
+        },
         "django": {
             "hashes": [
-                "sha256:a32c22af23634e1d11425574dce756098e015a165be02e4690179889b207c7a8",
-                "sha256:d6393918da830530a9516bbbcbf7f1214c3d733738779f06b0f649f49cc698c3"
+                "sha256:275bec66fd2588dd517ada59b8bfb23d4a9abc5a362349139ddda3c7ff6f5ade",
+                "sha256:939652e9d34d7d53d74d5d8ef82a19e5f8bb2de75618f7e5360691b6e9667963"
             ],
             "index": "pypi",
-            "version": "==2.1.5"
+            "version": "==2.1.7"
         },
         "django-dotenv": {
             "hashes": [
@@ -75,6 +83,14 @@
             ],
             "index": "pypi",
             "version": "==2.1.0"
+        },
+        "django-heroku": {
+            "hashes": [
+                "sha256:2bc690aab89eedbe01311752320a9a12e7548e3b0ed102681acc5736a41a4762",
+                "sha256:6af4bc3ae4a9b55eaad6dbe5164918982d2762661aebc9f83d9fa49f6009514e"
+            ],
+            "index": "pypi",
+            "version": "==0.3.1"
         },
         "django-model-utils": {
             "hashes": [
@@ -154,10 +170,10 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [
@@ -194,6 +210,13 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "whitenoise": {
+            "hashes": [
+                "sha256:118ab3e5f815d380171b100b05b76de2a07612f422368a201a9ffdeefb2251c1",
+                "sha256:42133ddd5229eeb6a0c9899496bdbe56c292394bf8666da77deeb27454c0456a"
+            ],
+            "version": "==4.1.2"
         }
     },
     "develop": {

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn backend.wsgi:application --bind 0.0.0.0:8000 --workers 3 --access-logfile '-'
+web: gunicorn backend.wsgi:application --bind 0.0.0.0:${PORT} --workers 3 --access-logfile '-'

--- a/backend/backend/Procfile
+++ b/backend/backend/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn backend.wsgi

--- a/backend/backend/Procfile
+++ b/backend/backend/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn -b 0.0.0.0:${PORT} backend.wsgi

--- a/backend/backend/Procfile
+++ b/backend/backend/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn backend.wsgi
+web: gunicorn -b 0.0.0.0:${PORT} backend.wsgi

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -28,7 +28,9 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", False)
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "ymim-backend-staging.herokuapp.com"
+]
 
 
 # Application definition

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -29,7 +29,8 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 DEBUG = os.getenv("DEBUG", False)
 
 ALLOWED_HOSTS = [
-    "ymim-backend-staging.herokuapp.com"
+    "ymim-backend-staging.herokuapp.com",
+    "ymim-backend-production.herokuapp.com"
 ]
 
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -123,5 +123,9 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
-
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = "/static/"
+
+# Configure Django App for Heroku.
+import django_heroku
+django_heroku.settings(locals())


### PR DESCRIPTION
Closes #4 

Installed [django-heroku](https://pypi.org/project/django-heroku/) package, which automatically sets up Heroku deployment configurations.

Added a Procfile specifying use of Heroku's provided port.

Added Heroku urls to allowed hosts in Django.

Set STATIC_ROOT path for [collectstatic](https://docs.djangoproject.com/en/2.1/ref/contrib/staticfiles/#django-admin-collectstatic) files.  Heroku runs this when building a Django app.

https://ymim-frontend-staging.herokuapp.com/
https://ymim-frontend-production.herokuapp.com/
https://ymim-backend-staging.herokuapp.com/
https://ymim-backend-production.herokuapp.com/

frontend:
<img width="712" alt="screen shot 2019-02-20 at 6 30 08 pm" src="https://user-images.githubusercontent.com/37374036/53134667-afc96780-353d-11e9-93fb-d768f49cea1e.png">

backend:
<img width="717" alt="screen shot 2019-02-20 at 6 29 16 pm" src="https://user-images.githubusercontent.com/37374036/53134678-b821a280-353d-11e9-8e59-a0c616d4a11b.png">
