### PR TITLE
Footer negative margin-left

### DIFF
--- a/frontend/src/components/common/footer/index.css
+++ b/frontend/src/components/common/footer/index.css
@@ -82,6 +82,15 @@
   text-align: center;
 }
 
+ul.row.menu-text {
+  margin: 0;
+  padding: 0;
+}
+
+li.col.footer-link {
+  padding: 0 5px;
+}
+
 @media (min-width: 769px) and (max-width: 2560px) {
   .tsocial {
     display: none;
@@ -90,11 +99,10 @@
 
 @media only screen and (max-width: 768px) {
   .footer-list {
-    font-size: 12pt;
+    font-size: 14px;
   }
   .footer-link {
-    display: inline-block;
-    margin: 2vh;
+    margin: 10px;
   }
   .svg-inline--fa.fa-facebook.fa-w-16.facebook,
   .svg-inline--fa.fa-twitter.fa-w-16.twitter,

--- a/frontend/src/components/common/footer/index.jsx
+++ b/frontend/src/components/common/footer/index.jsx
@@ -14,8 +14,8 @@ export default class footer extends Component {
     return (
       <Container fluid={true} className="footer">
         <Col>
-          <Row className="justify-content-md-center">
-            <Col md="12" lg="12" xl="12">
+          <Row className="justify-content-md-center text-left">
+            <Col xs="12" sm="12" md="12" lg="12" xl="12" fluid="true">
               <nav>
                 <ul className="row menu-text">
                   <li className="col footer-link">
@@ -35,7 +35,7 @@ export default class footer extends Component {
                   </li>
                   <li className="col footer-link">
                     <Link className="footer-list" to="/meet-the-team">
-                      Meet the Team
+                      Team
                     </Link>
                   </li>
                   <li className="col footer-link">


### PR DESCRIPTION
### Issue: #187 

### Describe the problem being solved: Fixed negative margin in the navigation for mobile devices.

### Impacted areas in the application: footer, front-end

List general components of the application that this PR will affect: 
* 

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`

<h2>Galaxy</h2>
![galaxy s5](https://user-images.githubusercontent.com/28938627/62667226-61255380-b94c-11e9-8385-12cb5a1982c1.png)

<h2>iPhone 6/7/8</h2>
![Screenshot from 2019-08-07 19-41-30](https://user-images.githubusercontent.com/28938627/62667227-61255380-b94c-11e9-85a7-ca9161c902d2.png)