### PR TITLE
Feature/126/navbar left align

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.log
 
 */.env
+.env
 
 # dependencies
 frontend/node_modules/*

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -3,7 +3,7 @@ import os
 import dotenv
 
 
-#for future use
+# for future use
 
 # SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
 

--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -103,6 +103,10 @@ a.dropdown-item {
 
 /* responsiveness */
 @media all and (min-width: 768px) and (max-width: 2048px) {
+  .align-links {
+    padding-left: 166px;
+  }
+
   .ym-top {
     height: 140px;
   }
@@ -133,7 +137,7 @@ a.dropdown-item {
   }
 
   .align-links {
-    padding-left: 180px;
+    padding-left: 296px;
     color: white;
   }
 }

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -34,7 +34,7 @@ class NavBar extends Component {
                 <img className="logo" src={logo} alt="YMIM" />
               </Navbar.Brand>
               {/* first navbar (white) */}
-              <Nav className="mx-auto my-auto">
+              <Nav className="ml-lg-3 ml-xl-3 ml-auto mr-auto my-auto">
                 <NavLink className="nav-link-top mr-5" to="/about">
                   About
                 </NavLink>
@@ -74,8 +74,13 @@ class NavBar extends Component {
               <Navbar.Collapse isOpen={this.state.isOpen} navbar>
                 <Nav className="mx-auto my-auto align-links">
                   {/* resources  */}
-                  <NavLink className="resources-link" to="/resources.pdf" download target="_blank">
-                  Youth Resources
+                  <NavLink
+                    className="resources-link"
+                    to="/resources.pdf"
+                    download
+                    target="_blank"
+                  >
+                    Youth Resources
                   </NavLink>
                   {/* enroll  */}
                   <NavDropdown

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -72,7 +72,7 @@ class NavBar extends Component {
             <Navbar collapseOnSelect expand="lg">
               <Navbar.Toggle className="ml-3" onClick={this.toggle} />
               <Navbar.Collapse isOpen={this.state.isOpen} navbar>
-                <Nav className="mx-auto my-auto align-links">
+                <Nav className="ml-lg-3 ml-xl-3 ml-auto mr-auto my-auto align-links">
                   {/* resources  */}
                   <NavLink
                     className="resources-link"


### PR DESCRIPTION
### Issue: #126 

### Describe the problem being solved:

Changed the classes on the top nav bar to be left aligned when logo is present, screen width 1024px and higher, but still be centered when logo is not present.

Before:
![feature-126-before](https://user-images.githubusercontent.com/44384361/63478564-e4b46980-c44f-11e9-9c57-393720a1087d.png)

After:
![feature-126-after](https://user-images.githubusercontent.com/44384361/63478566-e8e08700-c44f-11e9-93eb-c1d9593638ce.png)

### Impacted areas in the application: 

First nav bar

List general components of the application that this PR will affect: 
* header

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
