### PR TITLE
Issue #194 Donate Link on Footer

### DIFF
--- a/frontend/src/components/common/footer/index.jsx
+++ b/frontend/src/components/common/footer/index.jsx
@@ -49,7 +49,7 @@ export default class footer extends Component {
                     </Link>
                   </li>
                   <li className="col footer-link">
-                    <Link className="footer-list" to="/events">
+                    <Link className="footer-list" to="/donate">
                       Donate
                     </Link>
                   </li>

--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -17,7 +17,7 @@
 
 /* tablet  and mobile */
 
-@media (max-width: 1023px){ 
+@media (max-width: 1023px) {
   .content-styling {
     margin-left: 8.33%;
     margin-right: 8.33%;


### PR DESCRIPTION
### Issue: #194 

### Describe the problem being solved:
The donate link in the footer was routing to the events page and not the donate page.

### Impacted areas in the application: 
Donate page and the footer

List general components of the application that this PR will affect: 
* Footer and route to the donate page
<img width="1058" alt="Screen Shot 2019-08-21 at 6 45 42 PM" src="https://user-images.githubusercontent.com/36147646/63556976-62d64600-c50c-11e9-861f-db4bb01f30d5.png">


PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
