### PR TITLE
Feature/133/about page formating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.log
 
 */.env
+.env
 
 # dependencies
 frontend/node_modules/*

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -3,7 +3,7 @@ import os
 import dotenv
 
 
-#for future use
+# for future use
 
 # SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
 

--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -17,7 +17,7 @@
 
 /* tablet  and mobile */
 
-@media (max-width: 1023px){ 
+@media (max-width: 1023px) {
   .content-styling {
     margin-left: 8.33%;
     margin-right: 8.33%;

--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -1,3 +1,8 @@
+#aboutPageContainer {
+  padding-left: 266px;
+  padding-right: 266px;
+}
+
 .images {
   margin: 0;
   margin-bottom: 40px;
@@ -14,6 +19,11 @@
 /* tablet */
 
 @media all and (min-width: 426px) and (max-width: 1023px) {
+  #aboutPageContainer {
+    padding-left: 133px;
+    padding-right: 133px;
+  }
+  
   .images {
     margin: 0;
     margin-bottom: 20px;
@@ -35,6 +45,10 @@
 /* mobile */
 
 @media all and (min-width: 300px) and (max-width: 425px) {
+  #aboutPageContainer {
+    padding-left: 20px;
+    padding-right: 20px;    
+  }
   .images {
     margin: 0;
     margin-bottom: 10px;

--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -23,7 +23,7 @@
     padding-left: 133px;
     padding-right: 133px;
   }
-  
+
   .images {
     margin: 0;
     margin-bottom: 20px;
@@ -47,7 +47,7 @@
 @media all and (min-width: 300px) and (max-width: 425px) {
   #aboutPageContainer {
     padding-left: 20px;
-    padding-right: 20px;    
+    padding-right: 20px;
   }
   .images {
     margin: 0;

--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -11,7 +11,7 @@ class About extends Component {
     return (
       <Container fluid="true">
         <SingleCarousel />
-        <Container>
+        <Container id="aboutPageContainer">
           <h1 className="heading"> About </h1>
           <h2 className="sub-heading">Our Mission</h2>
           <p className="text-left">


### PR DESCRIPTION
### Issue: #133 

### Describe the problem being solved:
Changed container padding to match moch up. Designed called for 266px horizontal padding, but the designed looked poor on tablets, so for tablets it was changed to 133px horizontal padding.

Computers (1024px width screenshots)
Before:
![feature-133-before-1024px](https://user-images.githubusercontent.com/44384361/63558042-d5492500-c510-11e9-9b1b-15407175f490.png)

After:
![feature-133-after-1024px](https://user-images.githubusercontent.com/44384361/63558050-de39f680-c510-11e9-9558-4d3dc7b69f87.png)

Tablets (768px width screenshots)
Before:
![feature-133-before-768px](https://user-images.githubusercontent.com/44384361/63558070-f742a780-c510-11e9-8063-161f4df407f0.png)

After:
![feature-133-after-768px](https://user-images.githubusercontent.com/44384361/63558072-fc075b80-c510-11e9-9131-4d182a3fce76.png)

### Impacted areas in the application: 
About Page

List general components of the application that this PR will affect: 
* about.jsx in static_pages

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
