### PR TITLE
fixed social media links on landing page

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -3,7 +3,7 @@ import os
 import dotenv
 
 
-#for future use
+# for future use
 
 # SENDGRID_API_KEY = os.getenv('SENDGRID_API_KEY')
 

--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -17,7 +17,7 @@
 
 /* tablet  and mobile */
 
-@media (max-width: 1023px){ 
+@media (max-width: 1023px) {
   .content-styling {
     margin-left: 8.33%;
     margin-right: 8.33%;

--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import "./mid.css";
 import { Container, Row, Col } from "react-bootstrap";
-import { Link } from "react-router-dom";
 
 class LowerMid extends Component {
   render() {
@@ -27,20 +26,22 @@ class LowerMid extends Component {
               Won't you join us?
             </div>
             <h2 className="sub-heading">RSVP and Find out More:</h2>
-            <Link
-              to="/https://www.eventbrite.com/ymim"
+            <a
+              href="https://www.eventbrite.com/o/young-masterbuilders-in-motion-inc-18024803549"
+              target="_blank"
               className="space-anchors"
               alt="Eventbrite"
             >
               Eventbrite
-            </Link>
-            <Link
-              to="/https://www.facebook.com/pg/theymim.events"
+            </a>
+            <a
+              href="https://www.facebook.com/theymim/"
+              target="_blank"
               className="space-anchors"
               alt="Facebook"
             >
               Facebook
-            </Link>
+            </a>
             <div>
               <button className="ym-button" id="enroll">
                 All News

--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -39,6 +39,7 @@
   font-size: 24pt;
   margin: 0 20px 0 0 !important;
   color: #519b46;
+  font-family: "Gotham Light Font", sans-serif;
 }
 
 .footer-image-header {
@@ -92,6 +93,7 @@
   .space-anchors {
     font-size: 14pt;
     color: #519b46;
+    font-family: "Gotham Light Font", sans-serif;
   }
   .ym-button {
     font-size: 15px;
@@ -134,6 +136,7 @@
   .space-anchors {
     font-size: 12pt;
     color: #519b46;
+    font-family: "Gotham Light Font", sans-serif;
   }
   .ym-button {
     font-size: 10px;


### PR DESCRIPTION
Ticket Number : #193

### Describe the problem being solved:
[-] Eventbrite and Facebook full links should be visible on the very next line (immediate beneath). Cancelled as per Tina after a discussion about design. Can be readdressed later.
[x] The links should direct the user upon click to the appropriate sites. Confirmed with Tina and Michelle that the user will be directed to a new tab of the appropriate site.
[x] The links should follow design mockup as per the following: HEX 519B46 and Gotham Light font.
### Impacted areas in the application: 
Landing page lower section
List general components of the application that this PR will affect: 
* Landing page social media links for Eventbrite and Facebook

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
![Screenshot from 2019-08-22 19-41-44](https://user-images.githubusercontent.com/29875882/63559017-0cb9d080-c515-11e9-9c83-0b9e0c4fa744.png)
