### PR TITLE
Feature/210/social media icons

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -79,8 +79,8 @@ a.dropdown-item {
 
 .social-media {
   color: #519b56;
-  width: 25px;
-  height: 25px;
+  width: 50px;
+  height: 50px;
 }
 
 /* donate button on second navbar (green) */

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -47,20 +47,23 @@ class NavBar extends Component {
               </Nav>
               {/* social media links */}
               <Nav id="tsocial" className="ml-auto">
-                <Nav.Link href="https://www.facebook.com/theymim/">
+                <Nav.Link href="https://www.facebook.com/theymim/" target="_blank">
                   <FontAwesomeIcon
                     className="social-media"
-                    icon={faFacebookSquare}
+                    icon={faFacebookSquare}                    
                   />
                 </Nav.Link>
-                <Nav.Link href="https://www.instagram.com/theyoungmasterbuilders">
+                <Nav.Link href="https://www.instagram.com/theyoungmasterbuilders" target="_blank">
                   <FontAwesomeIcon
                     className="social-media"
-                    icon={faInstagram}
+                    icon={faInstagram}                    
                   />
                 </Nav.Link>
-                <Nav.Link href="https://www.instagram.com/theyoungmasterbuilders">
-                  <FontAwesomeIcon className="social-media" icon={faTwitter} />
+                <Nav.Link href="https://www.twitter.com/YMIMtweets" target="_blank">
+                  <FontAwesomeIcon 
+                    className="social-media" 
+                    icon={faTwitter}                     
+                  />
                 </Nav.Link>
               </Nav>
             </Navbar>

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -47,23 +47,29 @@ class NavBar extends Component {
               </Nav>
               {/* social media links */}
               <Nav id="tsocial" className="ml-auto">
-                <Nav.Link href="https://www.facebook.com/theymim/" target="_blank">
+                <Nav.Link
+                  href="https://www.facebook.com/theymim/"
+                  target="_blank"
+                >
                   <FontAwesomeIcon
                     className="social-media"
-                    icon={faFacebookSquare}                    
+                    icon={faFacebookSquare}
                   />
                 </Nav.Link>
-                <Nav.Link href="https://www.instagram.com/theyoungmasterbuilders" target="_blank">
+                <Nav.Link
+                  href="https://www.instagram.com/theyoungmasterbuilders"
+                  target="_blank"
+                >
                   <FontAwesomeIcon
                     className="social-media"
-                    icon={faInstagram}                    
+                    icon={faInstagram}
                   />
                 </Nav.Link>
-                <Nav.Link href="https://www.twitter.com/YMIMtweets" target="_blank">
-                  <FontAwesomeIcon 
-                    className="social-media" 
-                    icon={faTwitter}                     
-                  />
+                <Nav.Link
+                  href="https://www.twitter.com/YMIMtweets"
+                  target="_blank"
+                >
+                  <FontAwesomeIcon className="social-media" icon={faTwitter} />
                 </Nav.Link>
               </Nav>
             </Navbar>

--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -11,14 +11,14 @@ class About extends Component {
     return (
       <Container fluid="true">
         <SingleCarousel />
-        <Container >
+        <Container>
           <Row id="aboutPageTextRow">
             <h1 className="heading"> About </h1>
             <h2 className="sub-heading">Our Mission</h2>
             <p className="text-left">
               The Young Masterbuilders in Motion (YMIM) inspires, connects, and
-              empowers young women orphans, adoptees, and foster youth alumnae to
-              thrive.
+              empowers young women orphans, adoptees, and foster youth alumnae
+              to thrive.
             </p>
 
             <p className="text-left">
@@ -53,10 +53,10 @@ class About extends Component {
             </p>
 
             <p className="text-left">
-              We listen to participants, address their concerns, and help connect
-              them with resources to navigate life. We help participants develop
-              life skills necessary to thrive as the masterbuilder of their
-              future.
+              We listen to participants, address their concerns, and help
+              connect them with resources to navigate life. We help participants
+              develop life skills necessary to thrive as the masterbuilder of
+              their future.
             </p>
 
             <p className="text-left">
@@ -67,14 +67,15 @@ class About extends Component {
               mentoring and workshops on the precepts and concepts of
               entrepreneurship, sustained employment, global community service
               activities and more. **Our Road to Impactful Programming** Alumnae
-              input and feedback are the drivers of ongoing program enhancements.
-              Our pre and post self assessments provide our guideposts to
-              impactful programming. Participants of each age segment serve on
-              ideation and planning committees. Participant-centered needs is how
-              we determine where to prioritize cultural, education, life skills,
-              and employment programming.  **Resources and Referrals** We link
-              participants to resources and services beyond our capacity for those
-              desiring or requiring additional support.
+              input and feedback are the drivers of ongoing program
+              enhancements. Our pre and post self assessments provide our
+              guideposts to impactful programming. Participants of each age
+              segment serve on ideation and planning committees.
+              Participant-centered needs is how we determine where to prioritize
+              cultural, education, life skills, and employment programming. 
+              **Resources and Referrals** We link participants to resources and
+              services beyond our capacity for those desiring or requiring
+              additional support.
             </p>
           </Row>
           <h1 className="heading">Our People</h1>


### PR DESCRIPTION
### Issue: #210 

### Describe the problem being solved: 
Doubled the size of the social media icons in the header navigation bar as per the ticket request. 
Additional fixes as per consultation with Tina and Michelle:
Corrected the URL for the Twitter icon to YMIM's Twitter page (it had been previously set to YMIM's Instagram page). Directed the user to a new, separate page on click of each icon.

### Impacted areas in the application: 
Header Navigation Bar

List general components of the application that this PR will affect: 
Header Navigation Bar

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`

![Screenshot from 2019-08-28 18-59-51](https://user-images.githubusercontent.com/29875882/63900701-00c38800-c9c7-11e9-9862-0b3d2e02de6b.png)