### PR TITLE
Feature/95/landing page formating

### DIFF
--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -16,6 +16,7 @@
   text-align: center;
   margin-bottom: 35px;
   margin-top: 35px;
+  margin-right: 15px;
 }
 
 .heading {

--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -32,6 +32,7 @@
 
 .upper-mid-sectiontext {
   font-size: 15pt;
+  color: #697689;
 }
 
 .sub-heading {

--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -34,6 +34,8 @@
 .sub-heading {
   font-size: 24pt;
   padding-bottom: 15px;
+  padding-top: 15px;
+  font-weight: bold;
 }
 
 .space-anchors {

--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -20,8 +20,10 @@
 }
 
 .heading {
+  font-weight: bold;
   font-size: 36pt;
   padding: 15px 0;
+  margin-top: 25px;
 }
 
 .line-paragraph {


### PR DESCRIPTION
### Issue: #95 

### Describe the problem being solved:

Adjusted landing page formatting to be in line with the mock-up

Before:

![feature-95-before](https://user-images.githubusercontent.com/44384361/64392129-05182280-d011-11e9-998c-fb35b37fa796.png)

After:

![feature-95-after](https://user-images.githubusercontent.com/44384361/64392134-0b0e0380-d011-11e9-9a8d-761f081fb673.png)

### Impacted areas in the application: 

Home page

List general components of the application that this PR will affect: 
* home/midsection/lower-mid.jsx
* home/midsection/upper-mid.jsx
* home/midsection/mid.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
