### PR TITLE
changed the enroll link in subnav to be a link to /enrollment

### DIFF
--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -92,22 +92,9 @@ class NavBar extends Component {
                     Youth Resources
                   </NavLink>
                   {/* enroll  */}
-                  <NavDropdown
-                    className="nav-link"
-                    to="/enroll"
-                    title="Enroll"
-                    id="nav-dropdown"
-                  >
-                    <NavDropdown.Item eventKey="4.1" href="/enrollment">
-                      Program Participant
-                    </NavDropdown.Item>
-                    <NavDropdown.Item eventKey="4.2" href="/ambassadors">
-                      Volunteer Ambassadors
-                    </NavDropdown.Item>
-                    <NavDropdown.Item eventKey="4.3" href="/events">
-                      Events
-                    </NavDropdown.Item>
-                  </NavDropdown>
+                  <NavLink className="resources-link" to="/enrollment">
+                    Enroll
+                  </NavLink>
                   {/* volunteer  */}
                   <NavDropdown
                     className="nav-link"


### PR DESCRIPTION
### Issue: #219 

### Describe the problem being solved:

Changed Enroll link in subnav

Before:
![feature-219-before](https://user-images.githubusercontent.com/44384361/64576318-a1a63180-d33d-11e9-8d05-4707d18b1d10.png)

After:
![feature-219-after](https://user-images.githubusercontent.com/44384361/64576320-a4a12200-d33d-11e9-85e6-3a1be14ba9af.png)

### Impacted areas in the application: 
Enroll subnav

List general components of the application that this PR will affect: 
* components/common/header/navbar.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
