### PR TITLE
all navbar links now highlight yellow when they are the active page

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -51,6 +51,10 @@
   color: #fdd368;
 }
 
+.active {
+  color: #fdd368 !important;
+}
+
 /* dropdowns for resources, enroll, and volunteer */
 div.dropdown-menu.show {
   background-color: #519b56;


### PR DESCRIPTION
### Issue: #219 

### Describe the problem being solved:
Navbar Links now highlight in yellow when they are the active link

Before:
![feature-219-before](https://user-images.githubusercontent.com/44384361/65002279-a5dfcb00-d8b8-11e9-9c40-01362998d039.png)

After:
![feature-219-after](https://user-images.githubusercontent.com/44384361/65002283-aaa47f00-d8b8-11e9-90ca-22d5e255b73c.png)

### Impacted areas in the application: 
Navbar

List general components of the application that this PR will affect: 
* components/common/header/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
