### PR TITLE
Feature/140/meet the team page

### DIFF
--- a/frontend/src/components/static_pages/team.css
+++ b/frontend/src/components/static_pages/team.css
@@ -1,25 +1,25 @@
 .meetTheTeam {
-    padding: 20px 15px;
-    font-size: 1.2rem;
+  padding: 20px 15px;
+  font-size: 1.2rem;
 }
 
 .meetTheTeam h2 {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .teamPhotosArea {
-    background-color: #eeeaea;
+  background-color: #eeeaea;
 }
 
 .teamPhotos h2 {
-    padding: 20px;
+  padding: 20px;
 }
 
 .imageColumn {
-    padding-bottom: 20px;
+  padding-bottom: 20px;
 }
-  
-.gallery-picture{
-    width: 100%;
-    height: auto;
+
+.gallery-picture {
+  width: 100%;
+  height: auto;
 }

--- a/frontend/src/components/static_pages/team.css
+++ b/frontend/src/components/static_pages/team.css
@@ -1,0 +1,3 @@
+.gallery-picture{
+    width: 100%;
+}

--- a/frontend/src/components/static_pages/team.css
+++ b/frontend/src/components/static_pages/team.css
@@ -1,27 +1,22 @@
 .meetTheTeam {
-padding: 20px 15px;
-font-size: 1.2rem;
+    padding: 20px 15px;
+    font-size: 1.2rem;
 }
 
-.meetTheTeam h2,
-.teamPhotosArea h2 {
-margin-bottom: 20px;
+.meetTheTeam h2 {
+    margin-bottom: 20px;
 }
 
 .teamPhotosArea {
-background-color: #eeeaea;
+    background-color: #eeeaea;
 }
 
 .teamPhotos h2 {
-padding: 20px;
+    padding: 20px;
 }
 
-.teamPhotos {
-margin: 20px;
-}
-
-.teamPhotos Col {
-    padding-bottom: 10px;
+.imageColumn {
+    padding-bottom: 20px;
 }
   
 .gallery-picture{

--- a/frontend/src/components/static_pages/team.css
+++ b/frontend/src/components/static_pages/team.css
@@ -1,3 +1,30 @@
+.meetTheTeam {
+padding: 20px 15px;
+font-size: 1.2rem;
+}
+
+.meetTheTeam h2,
+.teamPhotosArea h2 {
+margin-bottom: 20px;
+}
+
+.teamPhotosArea {
+background-color: #eeeaea;
+}
+
+.teamPhotos h2 {
+padding: 20px;
+}
+
+.teamPhotos {
+margin: 20px;
+}
+
+.teamPhotos Col {
+    padding-bottom: 10px;
+}
+  
 .gallery-picture{
     width: 100%;
+    height: auto;
 }

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -1,5 +1,16 @@
 import React, { Component } from "react";
 import { Container, Col, Row } from "react-bootstrap";
+import "./team.css";
+import Picture1 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture2 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture3 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture4 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture5 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture6 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture7 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture8 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture9 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+
 
 class Team extends Component {
   render() {
@@ -41,20 +52,32 @@ class Team extends Component {
               </Col>
             </Row>
             <Row>
-              <Col>
-                <img src="images/dream_team.jpg" alt="dream team" />
+              <Col sm={4}>
+                <img src={Picture1} className="gallery-picture" alt="dream team" />
               </Col>
-              <Col>
-                <img src="images/donation.jpg" alt="donation" />
+              <Col sm={4}>
+                <img src={Picture2} className="gallery-picture" alt="donation" />
               </Col>
-            </Row>
-
-            <Row>
-              <Col>
-                <img src="images/jm_mw_ep.jpg" alt="jm_mw_ep" />
+              <Col sm={4}>
+                <img src={Picture3} className="gallery-picture" alt="jm_mw_ep" />
               </Col>
-              <Col>
-                <img src="images/calix.jpg" alt="calix" />
+              <Col sm={4}>
+                <img src={Picture4} className="gallery-picture" alt="calix" />
+              </Col>
+              <Col sm={4}>
+                <img src={Picture5} className="gallery-picture" alt="calix" />
+              </Col>
+              <Col sm={4}>
+                <img src={Picture6} className="gallery-picture" alt="calix" />
+              </Col>
+              <Col sm={4}>
+                <img src={Picture7} className="gallery-picture" alt="calix" />
+              </Col>
+              <Col sm={4}>
+                <img src={Picture8} className="gallery-picture" alt="calix" />
+              </Col>
+              <Col sm={4}>
+                <img src={Picture9} className="gallery-picture" alt="calix" />
               </Col>
             </Row>
           </Container>

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -1,16 +1,15 @@
 import React, { Component } from "react";
 import { Container, Col, Row } from "react-bootstrap";
 import "./team.css";
-import Picture1 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture2 from "../../assets/action-shots/Handmade drawstring bag donations.jpg"
-import Picture3 from "../../assets/action-shots/JM MW EP RPL 2.jpg"
-import Picture4 from "../../assets/action-shots/Rev Irene Min Trina KWKOIOEO pix wDonations.jpg"
-import Picture5 from "../../assets/action-shots/Team photo wKennedy.jpg"
-import Picture6 from "../../assets/action-shots/TTigue Sscott ASayre.jpg"
-import Picture7 from "../../assets/action-shots/UIC Dream Team SScott ACalix KWright.jpg"
-import Picture8 from "../../assets/action-shots/Calix family donors.jpg"
-import Picture9 from "../../assets/action-shots/Claxtons delivering donations.jpg"
-
+import Picture1 from "../../assets/action-shots/3 rows of donations lined up.jpg";
+import Picture2 from "../../assets/action-shots/Handmade drawstring bag donations.jpg";
+import Picture3 from "../../assets/action-shots/JM MW EP RPL 2.jpg";
+import Picture4 from "../../assets/action-shots/Rev Irene Min Trina KWKOIOEO pix wDonations.jpg";
+import Picture5 from "../../assets/action-shots/Team photo wKennedy.jpg";
+import Picture6 from "../../assets/action-shots/TTigue Sscott ASayre.jpg";
+import Picture7 from "../../assets/action-shots/UIC Dream Team SScott ACalix KWright.jpg";
+import Picture8 from "../../assets/action-shots/Calix family donors.jpg";
+import Picture9 from "../../assets/action-shots/Claxtons delivering donations.jpg";
 
 class Team extends Component {
   render() {
@@ -53,31 +52,31 @@ class Team extends Component {
             </Row>
             <Row>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture1} className="gallery-picture" alt="dream team" />
+                <img src={Picture1} className="gallery-picture" alt="Photo 1" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture2} className="gallery-picture" alt="donation" />
+                <img src={Picture2} className="gallery-picture" alt="Photo 2" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture3} className="gallery-picture" alt="jm_mw_ep" />
+                <img src={Picture3} className="gallery-picture" alt="Photo 3" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture4} className="gallery-picture" alt="calix" />
+                <img src={Picture4} className="gallery-picture" alt="Photo 4" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture5} className="gallery-picture" alt="calix" />
+                <img src={Picture5} className="gallery-picture" alt="Photo 5" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture6} className="gallery-picture" alt="calix" />
+                <img src={Picture6} className="gallery-picture" alt="Photo 6" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture7} className="gallery-picture" alt="calix" />
+                <img src={Picture7} className="gallery-picture" alt="Photo 7" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture8} className="gallery-picture" alt="calix" />
+                <img src={Picture8} className="gallery-picture" alt="Photo 8" />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <img src={Picture9} className="gallery-picture" alt="calix" />
+                <img src={Picture9} className="gallery-picture" alt="Photo 9" />
               </Col>
             </Row>
           </Container>

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -2,14 +2,14 @@ import React, { Component } from "react";
 import { Container, Col, Row } from "react-bootstrap";
 import "./team.css";
 import Picture1 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture2 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture3 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture4 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture5 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture6 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture7 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture8 from "../../assets/action-shots/3 rows of donations lined up.jpg"
-import Picture9 from "../../assets/action-shots/3 rows of donations lined up.jpg"
+import Picture2 from "../../assets/action-shots/Handmade drawstring bag donations.jpg"
+import Picture3 from "../../assets/action-shots/JM MW EP RPL 2.jpg"
+import Picture4 from "../../assets/action-shots/Rev Irene Min Trina KWKOIOEO pix wDonations.jpg"
+import Picture5 from "../../assets/action-shots/Team photo wKennedy.jpg"
+import Picture6 from "../../assets/action-shots/TTigue Sscott ASayre.jpg"
+import Picture7 from "../../assets/action-shots/UIC Dream Team SScott ACalix KWright.jpg"
+import Picture8 from "../../assets/action-shots/Calix family donors.jpg"
+import Picture9 from "../../assets/action-shots/Claxtons delivering donations.jpg"
 
 
 class Team extends Component {

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -52,31 +52,31 @@ class Team extends Component {
               </Col>
             </Row>
             <Row>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture1} className="gallery-picture" alt="dream team" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture2} className="gallery-picture" alt="donation" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture3} className="gallery-picture" alt="jm_mw_ep" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture4} className="gallery-picture" alt="calix" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture5} className="gallery-picture" alt="calix" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture6} className="gallery-picture" alt="calix" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture7} className="gallery-picture" alt="calix" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture8} className="gallery-picture" alt="calix" />
               </Col>
-              <Col sm={4}>
+              <Col className="imageColumn" sm={4}>
                 <img src={Picture9} className="gallery-picture" alt="calix" />
               </Col>
             </Row>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -97,30 +97,3 @@ code {
   border-radius: 50%;
   margin: 20px 0;
 }
-
-/* Here lies code for the team.jsx; Does this belong here */
-.meetTheTeam {
-  padding: 20px 266px;
-  font-size: 1.2rem;
-}
-
-.meetTheTeam h2,
-.teamPhotosArea h2 {
-  margin-bottom: 20px;
-}
-.teamPhotosArea {
-  background-color: #eeeaea;
-}
-
-.teamPhotos h2 {
-  padding: 20px;
-}
-
-.teamPhotosArea img {
-  padding: 20px;
-  height: 240px;
-}
-
-.teamPhotos {
-  margin: 20px;
-}


### PR DESCRIPTION
### Issue: #140 

### Describe the problem being solved:
Fixed the gallery to show 9 image in 3 columns (mobile is only 1 column), with correct centering and image resizing.
Before:
![feature-140-before](https://user-images.githubusercontent.com/44384361/65283294-60134480-dafc-11e9-938e-c346b78ef98f.png)

After:
![feature-140-after](https://user-images.githubusercontent.com/44384361/65283304-630e3500-dafc-11e9-90c1-0886de239726.png)

### Impacted areas in the application: 
Meet the Team page

List general components of the application that this PR will affect: 
* components/static_pages/team.jsx
* components/static_pages/team.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
