### PR TITLE
Feature/186/login page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - FRONTEND_URL=http://localhost:3000
       - POSTGRES_PASSWORD=password
     volumes:
-      - $PWD/backend:/code
+      - /home/khanh/Documents/ymim/ymim/backend:/code
     ports:
       - 8000:8000
     links:
@@ -24,7 +24,7 @@ services:
     build:
       context: frontend
     volumes:
-      - $PWD/frontend:/code
+      - /home/khanh/Documents/ymim/ymim/frontend:/code
     environment:
       - NODE_ENV=development
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - FRONTEND_URL=http://localhost:3000
       - POSTGRES_PASSWORD=password
     volumes:
-      - /home/khanh/Documents/ymim/ymim/backend:/code
+      - $PWD/backend:/code
     ports:
       - 8000:8000
     links:
@@ -24,7 +24,7 @@ services:
     build:
       context: frontend
     volumes:
-      - /home/khanh/Documents/ymim/ymim/frontend:/code
+      - $PWD/frontend:/code
     environment:
       - NODE_ENV=development
     ports:

--- a/frontend/src/components/common/footer/index.jsx
+++ b/frontend/src/components/common/footer/index.jsx
@@ -78,7 +78,7 @@ export default class footer extends Component {
                 </Col>
                 <Col xs="12" sm="12" md="4" lg="4" xl="2">
                   <Link className="contact" to="/login">
-                      Login
+                    Login
                   </Link>
                 </Col>
               </Row>

--- a/frontend/src/components/common/footer/index.jsx
+++ b/frontend/src/components/common/footer/index.jsx
@@ -76,6 +76,11 @@ export default class footer extends Component {
                 <Col xs="12" sm="12" md="4" lg="4" xl="2">
                   773.941.1200
                 </Col>
+                <Col xs="12" sm="12" md="4" lg="4" xl="2">
+                  <Link className="contact" to="/login">
+                      Login
+                  </Link>
+                </Col>
               </Row>
             </Col>
             <Col xs="10" sm="10">

--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -29,6 +29,7 @@ class LowerMid extends Component {
             <a
               href="https://www.eventbrite.com/o/young-masterbuilders-in-motion-inc-18024803549"
               target="_blank"
+              rel="noopener noreferrer"
               className="space-anchors"
               alt="Eventbrite"
             >
@@ -37,6 +38,7 @@ class LowerMid extends Component {
             <a
               href="https://www.facebook.com/theymim/"
               target="_blank"
+              rel="noopener noreferrer"
               className="space-anchors"
               alt="Facebook"
             >

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -65,9 +65,6 @@ class Login extends Component {
                       value={this.state.username}
                       onChange={this.handleInputChange}
                     />
-                    {errors.username.length > 0 && (
-                      <div className="style-error">{errors.username}</div>
-                    )}
                   </div>
                   <br />
                   <div>
@@ -81,9 +78,6 @@ class Login extends Component {
                       value={this.state.password}
                       onChange={this.handleInputChange}
                     />
-                    {errors.password.length > 0 && (
-                      <div className="style-error">{errors.password}</div>
-                    )}
                   </div>
                   <br />
                   <div>

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
-import { Container, Row, Col } from "react-bootstrap";
+import { Container, Row } from "react-bootstrap";
 import "./login.css";
-// import SingleCarousel from "../SingleCarousel";
 
 class Login extends Component {
   constructor(props) {
@@ -9,13 +8,32 @@ class Login extends Component {
 
     this.state = {
       username: "",
-      password: ""
+      password: "",
+      errors: {
+        username: "",
+        password: ""
+      },
+      usernameValid: false,
+      passwordValid: false,
+      formValid: false
     };
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
-  onFormSubmit = e => {
-    e.preventDefault();
+  handleInputChange = event => {
+    const { name, value } = event.target;
 
+    this.setState({
+      [name]: value
+    });
+  };
+
+  handleSubmit = event => {
+    event.preventDefault();
+
+    // proceed to the backend to validate the admin user data
     console.log("data is being sent", this.state);
     // fetch("http://the backend", {
     //   method: "POST",
@@ -32,15 +50,16 @@ class Login extends Component {
   };
 
   render() {
+    const { errors } = this.state;
+
     return (
       <div>
-        {/* <SingleCarousel /> */}
         <Container className="login">
-          <div> 
-            <Row>            
-            <form action="/" className="center-login" method="post">
-                <div className="style-login">
-                  <div>                    
+          <div>
+            <Row>
+              <form action="/" className="center-login" method="post">
+                <div className="container col-md-12 style-login">
+                  <div>
                     <input
                       id="username"
                       required=""
@@ -49,42 +68,53 @@ class Login extends Component {
                       placeholder="username"
                       className="col-md-12 inputs"
                       value={this.state.username}
+                      onChange={this.handleInputChange}
                     />
+                    {errors.username.length > 0 && (
+                      <div className="style-error">{errors.username}</div>
+                    )}
                   </div>
                   <br />
                   <div>
                     <input
                       id="password"
                       required=""
-                      type="text"
+                      type="password"
                       name="password"
                       placeholder="password"
                       className="col-md-12 inputs"
                       value={this.state.password}
+                      onChange={this.handleInputChange}
                     />
+                    {errors.password.length > 0 && (
+                      <div className="style-error">{errors.password}</div>
+                    )}
                   </div>
-                  <br />                  
+                  <br />
                   <div>
                     <p>
                       <button
-                        onClick={this.onFormSubmit}
+                        onClick={this.handleSubmit}
                         className="col-md-12 loginButton"
                         type="submit"
                         value="Submit"
+                        // disabled={!this.validateForm()}
                         // onChange={this.onChange}
                       >
                         <span className="buttonSpan">LOGIN</span>
                       </button>
                     </p>
                   </div>
-                  <div className="center-login" >
-                      <a className="password-link" href="">Forgot Password</a>
-                  </div>                    
+                  <div className="center-login">
+                    <a className="password-link" href="">
+                      Forgot Password
+                    </a>
+                  </div>
                   <br />
-                </div>                             
-            </form>
-            </Row>          
-          </div>          
+                </div>
+              </form>
+            </Row>
+          </div>
         </Container>
       </div>
     );

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -39,6 +39,7 @@ class Login extends Component {
           <div> 
             <Row>            
             <form action="/" className="center-login" method="post">
+                <div className="style-login">
                   <div>                    
                     <input
                       id="username"
@@ -76,7 +77,11 @@ class Login extends Component {
                       </button>
                     </p>
                   </div>
-                  <br />                             
+                  <div className="center-login" >
+                      <a className="password-link" href="">Forgot Password</a>
+                  </div>                    
+                  <br />
+                </div>                             
             </form>
             </Row>          
           </div>          

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -9,10 +9,6 @@ class Login extends Component {
     this.state = {
       username: "",
       password: "",
-      errors: {
-        username: "",
-        password: ""
-      }      
     };
 
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -82,8 +78,6 @@ class Login extends Component {
                         className="col-md-12 loginButton"
                         type="submit"
                         value="Submit"
-                        // disabled={!this.validateForm()}
-                        // onChange={this.onChange}
                       >
                         <span className="buttonSpan">LOGIN</span>
                       </button>

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -39,11 +39,6 @@ class Login extends Component {
     // }).then(function() {
     //   console.log("data has been set");
     // });
-
-    this.setState({
-      username: "",
-      password: ""
-    });
   };
 
   render() {

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -88,12 +88,7 @@ class Login extends Component {
                         <span className="buttonSpan">LOGIN</span>
                       </button>
                     </p>
-                  </div>
-                  <div className="center-login">
-                    <a className="password-link" href="">
-                      Forgot Password
-                    </a>
-                  </div>
+                  </div>                  
                   <br />
                 </div>
               </form>

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -12,10 +12,7 @@ class Login extends Component {
       errors: {
         username: "",
         password: ""
-      },
-      usernameValid: false,
-      passwordValid: false,
-      formValid: false
+      }      
     };
 
     this.handleInputChange = this.handleInputChange.bind(this);

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -47,8 +47,6 @@ class Login extends Component {
   };
 
   render() {
-    const { errors } = this.state;
-
     return (
       <div>
         <Container className="login">

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -1,0 +1,89 @@
+import React, { Component } from "react";
+import { Container, Row, Col } from "react-bootstrap";
+import "./login.css";
+// import SingleCarousel from "../SingleCarousel";
+
+class Login extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      username: "",
+      password: ""
+    };
+  }
+
+  onFormSubmit = e => {
+    e.preventDefault();
+
+    console.log("data is being sent", this.state);
+    // fetch("http://the backend", {
+    //   method: "POST",
+    //   body: JSON.stringify(this.state),
+    //   headers: { "Content-Type": "application/json" }
+    // }).then(function() {
+    //   console.log("data has been set");
+    // });
+
+    this.setState({
+      username: "",
+      password: ""
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        {/* <SingleCarousel /> */}
+        <Container className="login">
+          <div> 
+            <Row>            
+            <form action="/" className="center-login" method="post">
+                  <div>                    
+                    <input
+                      id="username"
+                      required=""
+                      type="text"
+                      name="username"
+                      placeholder="username"
+                      className="col-md-12 inputs"
+                      value={this.state.username}
+                    />
+                  </div>
+                  <br />
+                  <div>
+                    <input
+                      id="password"
+                      required=""
+                      type="text"
+                      name="password"
+                      placeholder="password"
+                      className="col-md-12 inputs"
+                      value={this.state.password}
+                    />
+                  </div>
+                  <br />                  
+                  <div>
+                    <p>
+                      <button
+                        onClick={this.onFormSubmit}
+                        className="col-md-12 loginButton"
+                        type="submit"
+                        value="Submit"
+                        // onChange={this.onChange}
+                      >
+                        <span className="buttonSpan">LOGIN</span>
+                      </button>
+                    </p>
+                  </div>
+                  <br />                             
+            </form>
+            </Row>          
+          </div>          
+        </Container>
+      </div>
+    );
+  }
+}
+
+export default Login;

--- a/frontend/src/components/login/login.css
+++ b/frontend/src/components/login/login.css
@@ -20,11 +20,6 @@
   text-decoration: none;
 }
 
-.style-error {
-  text-align: left;
-  color: red;
-}
-
 .style-login {
   margin: 0 0 3% 0;
   padding: 50px 0px 10px 0px;

--- a/frontend/src/components/login/login.css
+++ b/frontend/src/components/login/login.css
@@ -1,0 +1,17 @@
+.center-login {
+    margin: 0 auto;
+}
+.login {
+    margin: 5% auto;
+}
+.loginButton {
+    background-color: #519B46;
+    color: #FFF;
+}
+
+/* @media (min-width: 769px) and (max-width: 2560px) {
+    
+}
+@media only screen and (max-width: 768px) {
+
+} */

--- a/frontend/src/components/login/login.css
+++ b/frontend/src/components/login/login.css
@@ -29,9 +29,6 @@
   .style-login {
     border: 10px solid #519b46;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -moz-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -o-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
     padding: 50px 10px 10px 10px;
   }
 }
@@ -40,9 +37,6 @@
   .style-login {
     border: 15px solid #519b46;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -moz-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
-    -o-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
     padding: 50px 50px 10px 50px;
   }
 }

--- a/frontend/src/components/login/login.css
+++ b/frontend/src/components/login/login.css
@@ -1,12 +1,28 @@
 .center-login {
     margin: 0 auto;
+    text-align: center
 }
 .login {
-    margin: 5% auto;
+    margin: 4% auto;
 }
 .loginButton {
     background-color: #519B46;
     color: #FFF;
+}
+.password-link {
+    color: #519B46;
+}
+.password-link:hover {
+    text-decoration: none;
+}
+.style-login {
+    border: 15px solid #519B46;    
+    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
+    -moz-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
+    -webkit-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
+    -o-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
+    margin: 0 0 3% 0;
+    padding: 50px 50px 10px 50px;
 }
 
 /* @media (min-width: 769px) and (max-width: 2560px) {

--- a/frontend/src/components/login/login.css
+++ b/frontend/src/components/login/login.css
@@ -1,33 +1,53 @@
 .center-login {
-    margin: 0 auto;
-    text-align: center
+  margin: 0 auto;
+  text-align: center;
 }
+
 .login {
-    margin: 4% auto;
+  margin: 4% auto;
 }
+
 .loginButton {
-    background-color: #519B46;
-    color: #FFF;
+  background-color: #519b46;
+  color: #fff;
 }
+
 .password-link {
-    color: #519B46;
+  color: #519b46;
 }
+
 .password-link:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
+
+.style-error {
+  text-align: left;
+  color: red;
+}
+
 .style-login {
-    border: 15px solid #519B46;    
-    box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
-    -moz-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
-    -webkit-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
-    -o-box-shadow: 0 4px 8px 0 rgba(0,0,0,0.6);
-    margin: 0 0 3% 0;
+  margin: 0 0 3% 0;
+  padding: 50px 0px 10px 0px;
+}
+
+@media only screen and (min-width: 398px) {
+  .style-login {
+    border: 10px solid #519b46;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -moz-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -o-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    padding: 50px 10px 10px 10px;
+  }
+}
+
+@media only screen and (min-width: 500px) {
+  .style-login {
+    border: 15px solid #519b46;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -moz-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
+    -o-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.6);
     padding: 50px 50px 10px 50px;
+  }
 }
-
-/* @media (min-width: 769px) and (max-width: 2560px) {
-    
-}
-@media only screen and (max-width: 768px) {
-
-} */

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -8,7 +8,7 @@ import Home from "./components/home";
 import Header from "./components/common/header";
 import NotFound from "./components/common/not_found";
 import Footer from "./components/common/footer";
-import Login from "./components/common/login";
+import Login from "./components/login";
 import Contact from "./components/static_pages/contact";
 import About from "./components/static_pages/about";
 import Admin from "./components/admin";


### PR DESCRIPTION
### Issue: #186 Login Page

### Describe the problem being solved:
Acceptance Criteria:
Login access should be present in footer
Login screen should display per screenshot.
[-]Username should be 8 characters, comprised of alphas and numerals
[-]When incorrect user name entered, an error message should be displayed.
[-]Password should be 10 characters and be comprised of alphas, numerals and ONE special character
[-]When incorrect password entered, an error message should be displayed.
[-]If one or both fields are entered incorrectly, user should not be granted access.
User should have a link to recover password that says, "Forgot password" under button. (Inactive link for now).
Notes: For the above items marked [-], the consensus with the group is that username and password validations will be done when a new user registers for a login. Also, the back end will be responsible for the validations. There is a placeholder login.jsx file present in the common directory. This file may be removed after review of this pull request.

### Impacted areas in the application: 
* Footer (just added access to the login page)
* Router.js file (routed the "Login" link to this new page)
* Login page (new)

List general components of the application that this PR will affect: 
Footer
![Screenshot from 2019-09-20 16-22-58](https://user-images.githubusercontent.com/29875882/65359696-f14cee80-dbc2-11e9-9f2b-6d04d3223467.png)

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
