### PR TITLE
Manage.py has syntax error

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -11,6 +11,5 @@ if __name__ == "__main__":
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) 
-        from exc
+        ) from exc
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
### Issue: #242 

### Describe the problem being solved:

When running `docker-compose up`, an error occurs due to an errant line break in `backend/manage.py`.

### Impacted areas in the application: 

List general components of the application that this PR will affect: 
* 

PR checklist
- [-] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
