### PR TITLE
Feature/95/button links

### DIFF
--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -14,10 +14,9 @@
   padding-top: 25px;
   text-align: center;
 }
-.content-styling a{
+.content-styling a {
   font-size: 22px;
 }
-
 
 /* tablet  and mobile */
 

--- a/frontend/src/components/donation_page/index.jsx
+++ b/frontend/src/components/donation_page/index.jsx
@@ -36,7 +36,11 @@ class Donate extends Component {
           <div className="mx-auto donate">
             <form action="https://www.paypal.com/" method="post" target="_top">
               <input type="hidden" name="cmd" value="_s-xclick" />
-              <input type="hidden" name="hosted_button_id" value="34L62HLMP5VEC" />
+              <input
+                type="hidden"
+                name="hosted_button_id"
+                value="34L62HLMP5VEC"
+              />
               <input
                 type="hidden"
                 name="hosted_button_id"

--- a/frontend/src/components/events/EventList.js
+++ b/frontend/src/components/events/EventList.js
@@ -7,9 +7,9 @@ import moment from "moment";
 
 const EventList = ({ events }) => {
   events.sort((a, b) => moment(a.start.local) - moment(b.start.local));
-  const currentTime = moment()
-  const upcomingEvents = findUpcomingEvents(events, currentTime)
-  const pastEvents = findPastEvents(events, currentTime)
+  const currentTime = moment();
+  const upcomingEvents = findUpcomingEvents(events, currentTime);
+  const pastEvents = findPastEvents(events, currentTime);
   if (upcomingEvents.length === 0) {
     return (
       <div>
@@ -18,34 +18,23 @@ const EventList = ({ events }) => {
           Check back again soon for what is coming up next for YMIM. If you have
           an event that you think YMIM should be a part of please email:
           Founder@theymim.org or call: 773.941.1200.
-      </div>
+        </div>
         <EventSection events={pastEvents} isUpcoming={false} />
       </div>
     );
-  }
-  else if (upcomingEvents.length === 1) {
+  } else if (upcomingEvents.length === 1) {
     return (
       <div>
         <FeatureEvent event={upcomingEvents} />
-        <EventSection
-          events={pastEvents}
-          isUpcoming={false}
-        />
+        <EventSection events={pastEvents} isUpcoming={false} />
       </div>
-    )
-  }
-  else {
+    );
+  } else {
     return (
       <div>
         <FeatureEvent event={upcomingEvents[0]} />
-        <EventSection
-          events={upcomingEvents.slice(1)}
-          isUpcoming={true}
-        />
-        <EventSection
-          events={pastEvents}
-          isUpcoming={false}
-        />
+        <EventSection events={upcomingEvents.slice(1)} isUpcoming={true} />
+        <EventSection events={pastEvents} isUpcoming={false} />
       </div>
     );
   }

--- a/frontend/src/components/events/utils.js
+++ b/frontend/src/components/events/utils.js
@@ -1,9 +1,9 @@
 import moment from "moment";
 
 export function findUpcomingEvents(events, currentTime) {
-  return events.filter(event => moment(event.end.local).isAfter(currentTime))
+  return events.filter(event => moment(event.end.local).isAfter(currentTime));
 }
 
 export function findPastEvents(events, currentTime) {
-  return events.filter(event => moment(event.end.local).isBefore(currentTime))
+  return events.filter(event => moment(event.end.local).isBefore(currentTime));
 }

--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -26,31 +26,30 @@ class LowerMid extends Component {
               we care. We know it's an urgent situation. We need your support!
               Won't you join us?
             </div>
+
             <h2 className="sub-heading">RSVP and Find out More:</h2>
-            <a
-              href="https://www.eventbrite.com/o/young-masterbuilders-in-motion-inc-18024803549"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="space-anchors"
-              alt="Eventbrite"
-            >
-              Eventbrite
-            </a>
-            <a
-              href="https://www.facebook.com/theymim/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="space-anchors"
-              alt="Facebook"
-            >
-              Facebook
-            </a>
             <div>
               <button className="ym-button" id="enroll">
-                All News
+                <a
+                  href="https://www.facebook.com/theymim/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="button-anchors"
+                  alt="Facebook"
+                >
+                  Facebook
+                </a>
               </button>
               <button className="ym-button" id="enroll">
-                All Events
+                <a
+                  href="https://www.eventbrite.com/o/young-masterbuilders-in-motion-inc-18024803549"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="button-anchors"
+                  alt="Eventbrite"
+                >
+                  Eventbrite
+                </a>
               </button>
             </div>
           </Col>

--- a/frontend/src/components/home/midsection/mid.css
+++ b/frontend/src/components/home/midsection/mid.css
@@ -11,11 +11,11 @@
   font-weight: bold;
   background-color: #fdd368;
   border-radius: 2px;
-  width: 140px;
+  width: 180px;
   height: 54px;
   text-align: center;
   margin-bottom: 35px;
-  margin-top: 35px;
+  margin-top: 5px;
   margin-right: 15px;
 }
 
@@ -44,11 +44,12 @@
 }
 
 /* links to facebook and eventbrite */
-.space-anchors {
+.button-anchors {
   font-size: 24pt;
-  margin: 0 20px 0 0 !important;
-  color: #519b46;
-  text-decoration: none !important ;
+  font-weight: bold;
+  color: black;
+  text-decoration: none !important;
+  font-family: "Gotham Light Font", sans-serif;
 }
 
 /* buttons for news and events */
@@ -105,11 +106,8 @@
     margin-right: 8.33%;
     justify-content: center;
   }
-  .space-anchors {
+  .button-anchors {
     font-size: 14pt;
-    color: #519b46;
-    text-decoration: none !important;
-    font-family: "Gotham Light Font", sans-serif;
   }
   .ym-button {
     font-size: 15px;
@@ -150,11 +148,8 @@
     margin-right: 8.33%;
     justify-content: center;
   }
-  .space-anchors {
+  .button-anchors {
     font-size: 12pt;
-    color: #519b46;
-    text-decoration: none !important;
-    font-family: "Gotham Light Font", sans-serif;
   }
   .ym-button {
     font-size: 10px;

--- a/frontend/src/components/login/index.jsx
+++ b/frontend/src/components/login/index.jsx
@@ -8,7 +8,7 @@ class Login extends Component {
 
     this.state = {
       username: "",
-      password: "",
+      password: ""
     };
 
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -82,7 +82,7 @@ class Login extends Component {
                         <span className="buttonSpan">LOGIN</span>
                       </button>
                     </p>
-                  </div>                  
+                  </div>
                   <br />
                 </div>
               </form>

--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -38,7 +38,7 @@
 
   .images {
     margin: 0;
-    height: 350px
+    height: 350px;
   }
 
   .images img {

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -141,9 +141,11 @@ class Team extends Component {
                 />
               </Col>
               <Col className="imageColumn" sm={4}>
-                <a href="https://www.facebook.com/theymim/"
-                   target="_blank"
-                   rel="noopener noreferrer">
+                <a
+                  href="https://www.facebook.com/theymim/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <div className="facebookLinkContainer">
                     <p>Click here for more photos of the team.</p>
                   </div>


### PR DESCRIPTION
### Issue: #95 

### Describe the problem being solved:
Merged facebook and eventbrite links into the all news and all events buttons below them.

Before:
![feature-95-buttons-before](https://user-images.githubusercontent.com/44384361/66793948-3532cb00-eec5-11e9-8afa-a2c01c5a28bb.png)

After:
![feature-95-buttons-after](https://user-images.githubusercontent.com/44384361/66793952-39f77f00-eec5-11e9-9782-e8008ab0a312.png)

### Impacted areas in the application: 
Landing page

List general components of the application that this PR will affect: 
* /frontend/src/components/home/midsection/lower_mid.jsx
* /frontend/src/components/home/midsection/mid.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
