### PR TITLE
Hotfix/events page: Limit upcoming events to within next 30 days

### DIFF
--- a/frontend/src/components/events/index.jsx
+++ b/frontend/src/components/events/index.jsx
@@ -6,7 +6,7 @@ import EventList from "./EventList";
 import Flex from "./atoms/flex/flex";
 import {
   getSorted,
-  getUpcomingEvents,
+  getNextMonthsEvents,
   getPastEvents
 } from "../../reducers/selectors";
 
@@ -46,7 +46,7 @@ class Events extends Component {
 
 const mapStateToProps = state => {
   return {
-    upcomingEvents: getUpcomingEvents(getSorted(state.events)),
+    upcomingEvents: getNextMonthsEvents(getSorted(state.events)),
     pastEvents: getPastEvents(getSorted(state.events))
   };
 };

--- a/frontend/src/reducers/selectors.js
+++ b/frontend/src/reducers/selectors.js
@@ -11,6 +11,10 @@ export const getSorted = events => {
 };
 
 export const getUpcomingEvents = events => {
+  return events.filter(event => moment(event.end.local).isAfter(currentTime));
+};
+
+export const getNextMonthsEvents = events => {
   return events.filter(event =>
     moment(event.end.local).isBetween(currentTime, upcomingEnd)
   );

--- a/frontend/src/reducers/selectors.js
+++ b/frontend/src/reducers/selectors.js
@@ -16,7 +16,7 @@ export const getUpcomingEvents = events => {
 
 export const getNextMonthsEvents = events => {
   return events.filter(event =>
-    moment(event.end.local).isBetween(currentTime, upcomingEnd)
+    moment(event.start.local).isBetween(currentTime, upcomingEnd)
   );
 };
 

--- a/frontend/src/reducers/selectors.js
+++ b/frontend/src/reducers/selectors.js
@@ -1,14 +1,19 @@
 import moment from "moment";
 const currentTime = moment();
+const upcomingEnd = currentTime.add(30, "days");
 
 export const getSorted = events => {
   return events
     .sort((a, b) => moment(a.start.local) - moment(b.start.local))
-    .filter(e => ["live", "started", "ended", "completed"].includes(e.status));
+    .filter(event =>
+      ["live", "started", "ended", "completed"].includes(event.status)
+    );
 };
 
 export const getUpcomingEvents = events => {
-  return events.filter(event => moment(event.end.local).isAfter(currentTime));
+  return events.filter(event =>
+    moment(event.end.local).isBetween(currentTime, upcomingEnd)
+  );
 };
 
 export const getPastEvents = events => {


### PR DESCRIPTION
### Issue: N/A

### Describe the problem being solved:
**Before** 
Upcoming events should be limited to within the next 30 days.
![before](https://user-images.githubusercontent.com/37196330/67253538-ae8a6a80-f43d-11e9-9e14-6fada7137a7f.jpg)
**After**
![after](https://user-images.githubusercontent.com/37196330/67253542-afbb9780-f43d-11e9-8ec7-7836e1fb4150.jpg)

### Impacted areas in the application: 

List general components of the application that this PR will affect: 
* 

PR checklist
- [X] I included  a screenshot for FE changes
- [ ] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
- [X] I have run the [prettier](https://prettier.io/) command `make pretty`
