### PR TITLE
adjusted spacing in navbar for mobile

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -183,4 +183,13 @@ a.dropdown-item {
   .donate {
     font-size: 50px;
   }
+
+  .resources-link {
+    padding: 5px 8px;
+  }
+
+  .align-links {
+    padding-top: 35px;
+    padding-bottom: 15px;
+  }
 }

--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -185,11 +185,11 @@ a.dropdown-item {
   }
 
   .resources-link {
-    padding: 5px 8px;
+    padding: 0px 8px;
   }
 
   .align-links {
-    padding-top: 35px;
+    padding-top: 15px;
     padding-bottom: 15px;
   }
 }


### PR DESCRIPTION
### Issue: #265 

### Describe the problem being solved:
- [x] increase space between the bottom of the hamburger icon and first item in the dropdown
- [x] decrease space between items in the drop down list

### Impacted areas in the application: 
* navbar

List general components of the application that this PR will affect: 
* common

![Screenshot from 2019-10-23 20-20-20](https://user-images.githubusercontent.com/29875882/67445461-9e57c400-f5d2-11e9-9187-f77b85955e8c.png)

![Screenshot from 2019-10-23 20-23-25](https://user-images.githubusercontent.com/29875882/67445582-0908ff80-f5d3-11e9-8c96-b0b084e9cc27.png)

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`

