### PR TITLE
increased font size of video frame titles

### DIFF
--- a/frontend/src/components/Volunteer/volunteer.css
+++ b/frontend/src/components/Volunteer/volunteer.css
@@ -24,7 +24,7 @@
 
 .videoFrameTitle {
   color: #6ab446;
-  font-size: 16px;
+  font-size: 20px;
   margin-bottom: 20px;
   text-transform: uppercase;
 }


### PR DESCRIPTION
### Issue: #254 

### Describe the problem being solved:
Increase video frame title size from 16px to 20px

After:
![feature-254-after-2](https://user-images.githubusercontent.com/44384361/67533013-1d5e0280-f68e-11e9-8560-02c6e8ecde6c.png)


### Impacted areas in the application: 
Volunteer page videos

List general components of the application that this PR will affect: 
* /frontend/src/components/Volunteer/volunteer.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
