### PR TITLE
replaced form below text to accompanying form

### DIFF
--- a/frontend/src/components/enroll/enroll.md
+++ b/frontend/src/components/enroll/enroll.md
@@ -6,4 +6,4 @@ To apply, please send us your personal statement describing why you would like t
 
 Note: Each applicant is required to have two adult references with complete contact information provided in the email submission.
 
-The form below is a general participant interest form that helps us plan for number and age groups of potential cohort members, not to be confused with the enrollment application that will need to be submitted via email to **Founder@TheYMIM.org** noted above.
+The accompanying form is a general participant interest form that helps us plan for number and age groups of potential cohort members, not to be confused with the enrollment application that will need to be submitted via email to **Founder@TheYMIM.org** noted above.


### PR DESCRIPTION
### Issue: #293 

before:
![before-the-form-below-text](https://user-images.githubusercontent.com/46173001/68172392-f67cb780-ff3c-11e9-8568-934afb3c41a1.png)

after:
![after-accompanying-form-text](https://user-images.githubusercontent.com/46173001/68172299-a3a30000-ff3c-11e9-86d2-82678dc5fd9e.png)



### Describe the problem being solved: 

I replaced "The form below is a general" to "The accompanying form is a general" since the form on the Enroll page has changed.

### Impacted areas in the application: 

List general components of the application that this PR will affect: 
* 
frontend\src\components\enroll\enroll.md

PR checklist
- [X] I included  a screenshot for FE changes
- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
