### PR TITLE
Changed "FETCH_EVENTS" case in reducers/events.js. No longer saving

### DIFF
--- a/frontend/src/reducers/events.js
+++ b/frontend/src/reducers/events.js
@@ -5,7 +5,7 @@ export default function events(state = initialState, action) {
 
   switch (action.type) {
     case "FETCH_EVENTS":
-      return [...state, ...action.events];
+      return action.events || [];
 
     case "ADD_EVENT":
       return [...state, action.event];


### PR DESCRIPTION
### Issue: #303 

### Describe the problem being solved:
The first part of the bug ticket has been fixed. No more duplicate events load.

### Impacted areas in the application: 
Events Page

List general components of the application that this PR will affect: 
* 

PR checklist
- [N/A] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [N/A] I have run the [prettier](https://prettier.io/) command `make pretty`
