### PR TITLE
Donate Page - Mobile/Tablet/Desktop View - Decreased Spacing 

### DIFF
--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -5,7 +5,7 @@
 }
 
 .content-styling p {
-  padding-bottom: 25px;
+  line-height: 1.6em;
 }
 
 .donate-form {


### PR DESCRIPTION
### Issue: #307 

### Describe the problem being solved: 
decreased the line spacing between paragraphs on the donate page

### Impacted areas in the application: 
Before:
<img width="1439" alt="Screen Shot 2019-11-06 at 6 27 58 PM" src="https://user-images.githubusercontent.com/44908424/68350450-f2c86c80-00c5-11ea-9f59-ba3090fb60b9.png">

After: 
<img width="1434" alt="Screen Shot 2019-11-06 at 6 43 01 PM" src="https://user-images.githubusercontent.com/44908424/68350456-f8be4d80-00c5-11ea-8b8c-0517edef1c7a.png">

List general components of the application that this PR will affect: 
* frontend/src/components/donation_page/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
