### PR TITLE
Fixed splash section mobile view 2nd line

### DIFF
--- a/frontend/src/components/home/index.css
+++ b/frontend/src/components/home/index.css
@@ -57,6 +57,7 @@
   }
   .overlay {
     height: 50px;
+    margin-bottom: 16px;
   }
 }
 
@@ -75,5 +76,6 @@
   }
   .overlay {
     height: 70px;
+    margin-bottom: 16px;
   }
 }


### PR DESCRIPTION
### Issue:#326

### Describe the problem being solved:
Fixed splash section mobile view for second line
### Impacted areas in the application: 
<img width="497" alt="Screen Shot 2019-11-13 at 8 37 29 PM" src="https://user-images.githubusercontent.com/44477773/68822030-6eda2b80-0655-11ea-9b41-d0c77045ca8b.png">
<img width="441" alt="Screen Shot 2019-11-13 at 8 37 18 PM" src="https://user-images.githubusercontent.com/44477773/68822039-73064900-0655-11ea-98fb-f1c7542d0719.png">
<img width="384" alt="Screen Shot 2019-11-13 at 8 37 07 PM" src="https://user-images.githubusercontent.com/44477773/68822041-76013980-0655-11ea-8754-482823cfa899.png">

List general components of the application that this PR will affect: 
* frontend/src/components/home/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
