### PR TITLE
Bug/hotfix/featured future events not showing

### DIFF
--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -4,7 +4,7 @@ import { Container, Row, Col } from "react-bootstrap";
 import { connect } from "react-redux";
 import { events } from "../../../actions";
 import { findNextUpcomingEvent } from "../../events/utils";
-import { getSorted, getUpcomingEvents } from "../../../reducers/selectors";
+import { getSorted, getNextMonthsEvents } from "../../../reducers/selectors";
 import Moment from "react-moment";
 import footerImage1 from "../../../assets/footerImage1.jpg";
 import footerImage2 from "../../../assets/Group_at_a_table_YMIM.png";
@@ -107,7 +107,7 @@ class LowerMid extends Component {
 
 const mapStateToProps = state => {
   return {
-    upcomingEvents: getUpcomingEvents(getSorted(state.events))
+    upcomingEvents: getNextMonthsEvents(getSorted(state.events))
   };
 };
 

--- a/frontend/src/reducers/selectors.js
+++ b/frontend/src/reducers/selectors.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 const currentTime = moment();
-const upcomingEnd = currentTime.add(30, "days");
+const upcomingEnd = moment(currentTime).add(30, "days");
 
 export const getSorted = events => {
   return events
@@ -8,10 +8,6 @@ export const getSorted = events => {
     .filter(event =>
       ["live", "started", "ended", "completed"].includes(event.status)
     );
-};
-
-export const getUpcomingEvents = events => {
-  return events.filter(event => moment(event.end.local).isAfter(currentTime));
 };
 
 export const getNextMonthsEvents = events => {


### PR DESCRIPTION
### Issue: #303 

### Describe the problem being solved: After update to limit the future events to the next 30 days, the featured and upcoming events were no longer appearing. I determined that in selector.js the 30 days were being added to the currentTime variable instead of to the upcomingEnd variable. While inspecting the issue I also came across a function that was no longer necessary. Where the old function was being used in the home midsection I updated it to a more appropriate function.

### Impacted areas in the application: Events page Featured and Upcoming events. Home page Featured Event in the midsection

List general components of the application that this PR will affect: 
* 

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
