### PR TITLE
Added bold text on the splash section of the carousel on Volunteer Page

### DIFF
--- a/frontend/src/components/SingleCarousel/index.jsx
+++ b/frontend/src/components/SingleCarousel/index.jsx
@@ -17,8 +17,10 @@ class SingleCarousel extends Component {
             <div className="overlay">
               <h3 className="title-carousel">{this.props.header}</h3>
               <p className="paragraph-carousel">
-                Inspires, connects, and empowers young women orphans, adoptees,
-                and foster youth alumnae to thrive.
+                <strong>
+                  Inspires, connects, and empowers young women orphans,
+                  adoptees, and foster youth alumnae to thrive.
+                </strong>
               </p>
               <Navbar.Brand className="logo-div">
                 <img className="logo" src={logo} alt="YMIM" />


### PR DESCRIPTION
### Issue:#349

### Describe the problem being solved:
Added bold text on the splash section of the carousel on Volunteer Page
### Impacted areas in the application: 
Before:
<img width="974" alt="Screen Shot 2019-11-21 at 8 20 58 PM" src="https://user-images.githubusercontent.com/44477773/69392694-783e4600-0c9c-11ea-8d89-6fa82b657401.png">

After:
<img width="1290" alt="Screen Shot 2019-11-21 at 8 16 29 PM" src="https://user-images.githubusercontent.com/44477773/69392608-2d243300-0c9c-11ea-813b-d5b008160e8c.png">



List general components of the application that this PR will affect: 
* frontend/src/components/SingleCarousel/index.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
