### PR TITLE
Ticket #298 changed enroll pic

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11590,11 +11590,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-markdown": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.2.2.tgz",

--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -36,7 +36,7 @@ class Enroll extends Component {
         <SingleCarousel
           id="enroll-carousel"
           header="Young Masterbuilders in Motion"
-          image="ymim1.png"
+          image="ymim7.png"
         />
         <div className="container group mt-2">
           <div className="container col-sm-4 float-right mt-5">


### PR DESCRIPTION
### Issue: #298 

### Describe the problem being solved:
Needed to change background picture from picture of ladies facing backward to image of hands on top of each other.

Before:
![before-enroll-img](https://user-images.githubusercontent.com/46173001/70008041-0b4a6c00-1538-11ea-88c5-df27106a1504.png)

After:
![after-enroll-img](https://user-images.githubusercontent.com/46173001/70009031-42b91880-1538-11ea-9c11-cc08be72d3e9.png)

### Impacted areas in the application: 
\frontend\src\components\enroll\index.jsx

List general components of the application that this PR will affect: 
* enroll

PR checklist
- [X] I included  a screenshot for FE changes
- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
note: unable to 'make pretty' in my environment at the moment