### PR TITLE
Spacing Under "Donate Now!" 

### DIFF
--- a/frontend/src/components/donation_page/index.css
+++ b/frontend/src/components/donation_page/index.css
@@ -9,7 +9,8 @@
 }
 
 #donate-now {
-  padding-top: 20px;
+  text-align: center;
+  line-height: 1.6em;
 }
 
 .donate-form {


### PR DESCRIPTION
### Issue: #307

### Describe the problem being solved:
Increase the spacing under "Donate Now!" by a little to match the rest of the spacing on the page and centered "Donate Now!"
### Impacted areas in the application: 

Before:
<img width="1358" alt="Screen Shot 2019-12-04 at 7 45 58 PM" src="https://user-images.githubusercontent.com/44908424/70196634-010ea600-16cf-11ea-9f97-91008601b825.png">

After:
<img width="1350" alt="Screen Shot 2019-12-04 at 7 45 34 PM" src="https://user-images.githubusercontent.com/44908424/70196581-d02e7100-16ce-11ea-9058-742c184aa851.png">

List general components of the application that this PR will affect: 
* frontend/src/components/donation_page/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
