### PR TITLE
changed main carousel component to single carousel component on about…

### DIFF
--- a/frontend/src/components/enroll/index.js
+++ b/frontend/src/components/enroll/index.js
@@ -1,0 +1,61 @@
+import React, { Component } from "react";
+import Markdown from "react-markdown";
+import "./enroll.css";
+import Text from "./enroll.md";
+import "react-bootstrap";
+import SingleCarousel from "../SingleCarousel";
+
+class Enroll extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      text: null,
+      loadCounter: 0,
+      iframeHeight: 1275
+    };
+  }
+
+  componentWillMount() {
+    fetch(Text)
+      .then(response => response.text())
+      .then(text => {
+        this.setState({ text: text });
+      });
+  }
+
+  loaded = () => {
+    let height = this.state.loadCounter % 2 === 0 ? 1275 : 400;
+    let loadCounter = this.state.loadCounter + 1;
+    this.setState({ iframeHeight: height, loadCounter: loadCounter });
+  };
+
+  render() {
+    return (
+      <div>
+        <SingleCarousel
+          id="enroll-carousel"
+          header="Young Masterbuilders in Motion"
+          image="ymim1.png"
+        />
+        <div className="container group">
+          <div className="container col-sm-4 float-right mt-5">
+            <Markdown id="fontcss" className="mt-3 " source={this.state.text} />
+          </div>
+          <div className="container col-sm-8 mt-5">
+            <iframe
+              title="enroll"
+              src="https://docs.google.com/forms/d/e/1FAIpQLScH_lkw44ikfkHlHpUFVsAtXF6MzElK19xWUyVOP_mJ-ClmHw/viewform?embedded=true"
+              style={{ width: "100%", height: this.state.iframeHeight }}
+              frameborder="0"
+              onLoad={this.loaded}
+              className="enroll-iframe"
+            ></iframe>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Enroll;

--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import "./about.css";
-import MainCarousel from "../home/carousel";
+import SingleCarousel from "../SingleCarousel/index";
 import { Container, Row, Col } from "react-bootstrap";
 import PierrePriestley from "./../../assets/Pierre-Priestley_new.jpg";
 import ShirleyScott from "./../../assets/Shirley-Scott_new.jpg";
@@ -10,7 +10,11 @@ class About extends Component {
   render() {
     return (
       <Container fluid="true">
-        <MainCarousel />
+        <SingleCarousel
+          className="carousel"
+          header="Yong masterbuilders In Motion"
+          image="ymim6.png"
+        />
         <Container>
           <Row id="aboutPageTextRow">
             <h1 className="heading"> About </h1>


### PR DESCRIPTION

### Issue:#299

### Describe the problem being solved:
Changed the picture of the carousel on the About Page, and switched from Main Carousel Component to the Single Carousel Component in order to do that

### Impacted areas in the application: 
* frontend/src/components/static_pages/about.jsx

List general components of the application that this PR will affect: 
* Before: 
<img width="1440" alt="Screen Shot 2019-12-04 at 9 01 02 PM" src="https://user-images.githubusercontent.com/44477773/70200175-3c15d700-16d9-11ea-9ca0-feb0fed9bc8e.png">
<img width="1437" alt="Screen Shot 2019-12-04 at 9 00 35 PM" src="https://user-images.githubusercontent.com/44477773/70200183-4041f480-16d9-11ea-9aa4-f3c01fb36d2c.png">
<img width="1438" alt="Screen Shot 2019-12-04 at 9 00 11 PM" src="https://user-images.githubusercontent.com/44477773/70200194-4506a880-16d9-11ea-9917-73cf786f876a.png">

* After: 
<img width="1440" alt="Screen Shot 2019-12-04 at 8 55 39 PM" src="https://user-images.githubusercontent.com/44477773/70200015-e5100200-16d8-11ea-97fb-cca7e416ddfa.png">

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
