### PR TITLE
no-scroll on enroll page google form

### DIFF
--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -12,7 +12,7 @@ class Enroll extends Component {
     this.state = {
       text: null,
       loadCounter: 0,
-      iframeHeight: 1275
+      iframeHeight: 2000
     };
   }
 
@@ -25,7 +25,7 @@ class Enroll extends Component {
   }
 
   loaded = () => {
-    let height = this.state.loadCounter % 2 === 0 ? 1275 : 400;
+    let height = this.state.loadCounter % 2 === 0 ? 2000 : 400;
     let loadCounter = this.state.loadCounter + 1;
     this.setState({ iframeHeight: height, loadCounter: loadCounter });
   };

--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -54,6 +54,7 @@ class Enroll extends Component {
               frameborder="0"
               onLoad={this.loaded}
               className="enroll-iframe"
+              scrolling="no"
             ></iframe>
           </div>
         </div>


### PR DESCRIPTION
### Issue: #327

### Describe the problem being solved:
* Modify google form so it is not scrollable.
### Impacted areas in the application: 
Before:
![feature-327-enroll-page-mobile-no-scroll-before](https://user-images.githubusercontent.com/54036633/70487098-d9964f80-1ab9-11ea-9999-41930997eea6.png)

After:
![feature-327-enroll-page-mobile-no-scroll-after](https://user-images.githubusercontent.com/54036633/70487116-e2872100-1ab9-11ea-96b6-89f50f88637f.png)


List general components of the application that this PR will affect: 
* /frontend/src/components/enroll/index.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
