### PR TITLE
Corrected spelling for Carousel Header from "yong" to "Young"

### DIFF
--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import "./about.css";
-import MainCarousel from "../home/carousel";
+import SingleCarousel from "../SingleCarousel/index";
 import { Container, Row, Col } from "react-bootstrap";
 import PierrePriestley from "./../../assets/Pierre-Priestley_new.jpg";
 import ShirleyScott from "./../../assets/Shirley-Scott_new.jpg";
@@ -10,7 +10,11 @@ class About extends Component {
   render() {
     return (
       <Container fluid="true">
-        <MainCarousel />
+      <SingleCarousel
+        className="carousel"
+        header="Young Masterbuilders in Motion"
+        image="ymim6.png"
+      />
         <Container>
           <Row id="aboutPageTextRow">
             <h1 className="heading"> About </h1>


### PR DESCRIPTION
### Issue:#361

### Describe the problem being solved:
* corrected spelling for carousel's header, changed "Yong" to "Young" and "masterbuilders" to "Masterbuilders"

### Impacted areas in the application: 
Before: 
<img width="1187" alt="Screen Shot 2019-12-09 at 7 29 12 PM" src="https://user-images.githubusercontent.com/44477773/70487395-d8195700-1aba-11ea-9154-5d5f5c39d50b.png">

After:
<img width="1148" alt="Screen Shot 2019-12-09 at 7 34 16 PM" src="https://user-images.githubusercontent.com/44477773/70487471-1c0c5c00-1abb-11ea-8a80-1b7c3e91ac33.png">

List general components of the application that this PR will affect: 
* frontend/src/components/static_pages/about.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [x] I have run the [prettier](https://prettier.io/) command `make pretty`
