### PR TITLE
feature/296 replace volunteer-page photo

### DIFF
--- a/frontend/src/components/Volunteer/volunteer.jsx
+++ b/frontend/src/components/Volunteer/volunteer.jsx
@@ -27,7 +27,7 @@ class Volunteer extends Component {
         <SingleCarousel
           className="carousel"
           header="Young Masterbuilders in Motion"
-          image="ymim1.png"
+          image="volunteers.jpg"
         />
         <Container className="mt-4 content-format">
           <Row className="mx-auto flexForm">


### PR DESCRIPTION
### Issue:#296

### Describe the problem being solved:
- [x] Replace the existing photo on the page with the photo on this page: https://www.cpas4you.com/transforming-nonprofit-volunteers-into-long-term-supporters/
- [x] Crop the boys from the photo and only include the girls.
- [x] Make sure the photo size is the same as the original photo on the Volunteer page.
- [X] Modify the photo so it has a hazy look as the original photo on the Volunteer page.
### Impacted areas in the application: 
Before:
![feature-296-volunteer-page-design-photo-before](https://user-images.githubusercontent.com/54036633/70488878-a9ea4600-1abf-11ea-966c-c59668caf0ba.png)

After:
![feature-296-volunteer-page-design-photo-after](https://user-images.githubusercontent.com/54036633/70488894-b40c4480-1abf-11ea-917d-46e7791a3352.png)

List general components of the application that this PR will affect: 
*/frontend/src/components/Volunteer/volunteer.jsx
*/frontend/src/assets/volunteers.jpg

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
