### PR TITLE
Changed Green Section Menu Bar

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -12,7 +12,7 @@
   background-color: #519b56;
   font-size: 32px;
   font-family: "GothamMedium";
-  height: auto;
+  height: 100px !important;
   color: white;
   width: 100%;
 }
@@ -30,8 +30,8 @@
 
 .resources-link {
   height: 100%;
-  padding: 40px 8px 20px 8px;
-  margin-right: 15px;
+  padding: 20px 80px 20px 8px;
+  /* margin-right: 15px; */
   color: white !important;
   padding-bottom: 45px;
 }

--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -31,7 +31,6 @@
 .resources-link {
   height: 100%;
   padding: 20px 80px 20px 8px;
-  /* margin-right: 15px; */
   color: white !important;
   padding-bottom: 45px;
 }
@@ -98,12 +97,13 @@ a.dropdown-item {
   width: 140px;
   height: 54px;
   text-align: center;
+  margin-left: 70px;
 }
 
 /* spacing around donate button  */
 .center-button {
   margin-top: auto;
-  margin-bottom: auto;
+  margin-bottom: 52px;
 }
 
 /* responsiveness */
@@ -166,6 +166,8 @@ a.dropdown-item {
     font-size: 12px;
     width: 80px;
     height: 40px;
+    margin-left: 5px;
+    margin-top: 20px;
   }
 
   .center-button {


### PR DESCRIPTION
### Issue: #325 

### Describe the problem being solved:
I decreased the height for the green section so it matches the white section, and also changed padding for only the links: Resources/Enroll/Volunteer.

### Impacted areas in the application: 
Before:
<img width="1428" alt="Screen Shot 2019-12-09 at 8 00 31 PM" src="https://user-images.githubusercontent.com/44908424/70489243-c935a300-1ac0-11ea-8f09-daf9a5da76df.png">


After: 
<img width="1420" alt="Screen Shot 2019-12-09 at 7 57 00 PM" src="https://user-images.githubusercontent.com/44908424/70489312-06019a00-1ac1-11ea-98d2-0b5f7ae07454.png">

List general components of the application that this PR will affect: 
* frontend/src/components/common/header/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
