### PR TITLE
increase left and right margins for sponsors section

### DIFF
--- a/frontend/src/components/events/sponsors/index.css
+++ b/frontend/src/components/events/sponsors/index.css
@@ -4,5 +4,5 @@
 
 .logo-picture {
   max-width: 200px;
-  margin: 10px;
+  margin: 10px 30px;
 }


### PR DESCRIPTION
### Issue: #236 

### Describe the problem being solved: Increase left and right margin between sponsor logos

### Impacted areas in the application: Sponsor area of Events Page

List general components of the application that this PR will affect: 
* Sponsor


Before:

![Screenshot from 2019-12-09 20-53-01](https://user-images.githubusercontent.com/29875882/70491128-ff295600-1ac5-11ea-84e7-407d9bc6c4b3.png)


After:

![Screenshot from 2019-12-09 20-52-55](https://user-images.githubusercontent.com/29875882/70491105-ef117680-1ac5-11ea-8f32-d725b9198e0d.png)

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty` (No need since I only added a margin)
