### PR TITLE
Feature/368/contact page google form no horizontal scroll

### DIFF
--- a/frontend/src/components/Volunteer/volunteer.jsx
+++ b/frontend/src/components/Volunteer/volunteer.jsx
@@ -27,7 +27,7 @@ class Volunteer extends Component {
         <SingleCarousel
           className="carousel"
           header="Young Masterbuilders in Motion"
-          image="ymim1.png"
+          image="volunteers.jpg"
         />
         <Container className="mt-4 content-format">
           <Row className="mx-auto flexForm">

--- a/frontend/src/components/Volunteer/volunteer.jsx
+++ b/frontend/src/components/Volunteer/volunteer.jsx
@@ -27,7 +27,7 @@ class Volunteer extends Component {
         <SingleCarousel
           className="carousel"
           header="Young Masterbuilders in Motion"
-          image="volunteers.jpg"
+          image="ymim1.png"
         />
         <Container className="mt-4 content-format">
           <Row className="mx-auto flexForm">

--- a/frontend/src/components/static_pages/contact.jsx
+++ b/frontend/src/components/static_pages/contact.jsx
@@ -65,6 +65,7 @@ class Contact extends Component {
               onLoad={this.loaded}
               className="enroll-iframe"
               title="contact-iframe"
+              scrolling="no"
             >
               Loading…
             </iframe>


### PR DESCRIPTION
### Issue:#368

### Describe the problem being solved:
[] Modify google form so it is not horizontally scrollable.
### Impacted areas in the application: 
Before:
![feature-368-no-horizontal-scroll-before](https://user-images.githubusercontent.com/54036633/70672786-ee075300-1c45-11ea-9409-9a18564ffdbc.png)

AFTER:
![feature-368-no-horizontal-scroll-after](https://user-images.githubusercontent.com/54036633/70672800-f8295180-1c45-11ea-83a7-71eafb70e678.png)


List general components of the application that this PR will affect: 
* /frontend/src/components/static_pages/contact.jsx

PR checklist
- [X] I included  a screenshot for FE changes
- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
