### PR TITLE
feature/375 FIX: Meet the Team Page - Gray Box Pop up

### DIFF
--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -5,6 +5,7 @@ import Text from "./enroll.md";
 import "react-bootstrap";
 import SingleCarousel from "../SingleCarousel";
 
+
 class Enroll extends Component {
   constructor(props) {
     super(props);

--- a/frontend/src/components/static_pages/team.jsx
+++ b/frontend/src/components/static_pages/team.jsx
@@ -159,9 +159,6 @@ class Team extends Component {
                     src={Picture9}
                     className="gallery-picture"
                     alt="8"
-                    onClick={event => {
-                      this.selectImage(event);
-                    }}
                   />
                   <div className="facebookLink">
                     Click here for more photos of the team.


### PR DESCRIPTION
### Issue:#375

### Describe the problem being solved:
* The grey box should not pop up. It should only open up a new window linked to the client's facebook page.
### Impacted areas in the application: 
Before:  There was a pop up on the gray background "Click here for more photos of the team"  
After:
The pop-up was removed and it only links to the facebook page:
![feature-375-meet-the-teampage-after](https://user-images.githubusercontent.com/54036633/70957486-dc55ef00-203b-11ea-92fa-ce806cc0bf51.png)

List general components of the application that this PR will affect: 
* /frontend/src/components/static_pages/team.jsx
PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
