### PR TITLE
feature/378/modify right margin text on all splash pages

### DIFF
--- a/frontend/src/components/home/index.css
+++ b/frontend/src/components/home/index.css
@@ -52,6 +52,7 @@
   .paragraph-carousel {
     font-size: 16px;
     width: 100%;
+    padding-right: 20px;
   }
   .overlay {
     height: 100px;


### PR DESCRIPTION
### Issue:#378

### Describe the problem being solved:
* The text in the splash area in 768 by 844 view is very close to the right margin/cut off.
### Impacted areas in the application: 
Before:
![feature-378-fix-splash-mobile-view-before](https://user-images.githubusercontent.com/54036633/70960398-89cd0080-2044-11ea-97a8-b5ed398a0656.png)

After:
![feature-378-fix-splash-mobile-view-after](https://user-images.githubusercontent.com/54036633/70960431-9cdfd080-2044-11ea-9d06-701e6f2578ba.png)

List general components of the application that this PR will affect: 
* /frontend/src/components/home/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
