### PR TITLE
Changes made to the logo view in the splash section for the laptop view

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,12 +41,12 @@ code {
 
 .overlay {
   position: relative;
-  bottom: -40px;
+  bottom: -36px;
   width: 100%;
   background: rgba(81, 155, 70, 0.65);
   margin: 0;
   padding: 0;
-  height: 238px;
+  height: 216px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
### Issue:#383

### Describe the problem being solved:

Changes made to the logo view in the splash section for the laptop view
### Impacted areas in the application: 
* Before:
<img width="784" alt="Screen Shot 2019-12-18 at 8 07 07 PM" src="https://user-images.githubusercontent.com/44477773/71138728-04775680-21d2-11ea-8518-34dd36559470.png">

* After:
<img width="768" alt="Screen Shot 2019-12-18 at 8 03 09 PM" src="https://user-images.githubusercontent.com/44477773/71138743-0b05ce00-21d2-11ea-828c-73ee0305704f.png">

List general components of the application that this PR will affect: 
* frontend/src/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
