### PR TITLE
Fixed hamburger menu on tablet view

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -108,7 +108,7 @@ a.dropdown-item {
 /* responsiveness */
 @media all and (min-width: 768px) and (max-width: 2048px) {
   .align-links {
-    padding-left: 166px;
+    padding-left: 10px;
   }
 
   .ym-top {


### PR DESCRIPTION
### Issue:#389

### Describe the problem being solved:
- Fixed hamburger menu on tablet view

### Impacted areas in the application: 
Before:
<img width="634" alt="Screen Shot 2020-01-08 at 8 04 42 PM" src="https://user-images.githubusercontent.com/44477773/72031485-26ed1480-3252-11ea-98ef-dacb9ed57f8d.png">

After:
<img width="631" alt="Screen Shot 2020-01-08 at 7 59 51 PM" src="https://user-images.githubusercontent.com/44477773/72031250-77b03d80-3251-11ea-88d8-c8c57070143b.png">
List general components of the application that this PR will affect: 
* frontend/src/components/common/header/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
