### PR TITLE
Donate Button Tablet/Mobile/All Views

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -88,21 +88,19 @@ a.dropdown-item {
 }
 
 /* donate button on second navbar (green) */
-#donate-button {
+.donate-button {
   font-size: 20px;
   font-weight: bold;
   background-color: #fdd368;
   border-radius: 7px;
   border: none;
-  width: 140px;
+  width: 110px;
   height: 54px;
-  text-align: center;
-  margin-left: 70px;
-}
-/* spacing around donate button  */
-.center-button {
-  margin-top: auto;
-  margin-bottom: 52px;
+  margin-top: 23px;
+  margin-right: 30px;
+  position: absolute;
+  bottom: 5;
+  right: 0;
 }
 
 /* responsiveness */
@@ -162,17 +160,16 @@ a.dropdown-item {
     height: auto;
   }
 
-  #donate-button {
+  .donate-button {
     font-size: 12px;
     width: 80px;
-    height: 40px;
-    margin-left: 5px;
-    margin-top: 20px;
-  }
-
-  .center-button {
-    margin-top: 10px;
+    height: 45px;
+    margin-top: 28px;
+    margin-right: 30px;
     margin-bottom: 10px;
+    position: absolute;
+    bottom: 5;
+    right: 0;
   }
 
   #tsocial {

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -109,7 +109,7 @@ class NavBar extends Component {
           {/* donate button  */}
           <Col className="center-button" xs={4} sm={4} md={2} lg={2}>
             <NavLink to="/donate">
-              <button id="donate-button">Donate</button>
+              <button className="donate-button">Donate</button>
             </NavLink>
           </Col>
         </Row>

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -107,7 +107,7 @@ class NavBar extends Component {
             </Navbar>
           </Col>
           {/* donate button  */}
-          <Col className="center-button" xs={4} sm={4} md={2} lg={2}>
+          <Col xs={4} sm={4} md={2} lg={2}>
             <NavLink to="/donate">
               <button className="donate-button">Donate</button>
             </NavLink>


### PR DESCRIPTION
### Issue: #262 

### Describe the problem being solved:
Donate Button was moving around on different screen sizes, that issue is fixed. And I also checked for other little discrepancies in look on all screen views. 

### Impacted areas in the application: 
Before:
<img width="760" alt="Screen Shot 2020-01-09 at 12 35 58 AM" src="https://user-images.githubusercontent.com/44908424/72043962-31baa000-3278-11ea-8458-b9118b344eb4.png">

After:
<img width="729" alt="Screen Shot 2020-01-09 at 12 33 44 AM" src="https://user-images.githubusercontent.com/44908424/72043969-354e2700-3278-11ea-951a-a265f09df381.png">

List general components of the application that this PR will affect: 
* frontend/src/components/common/header/navbar.jsx
* frontend/src/components/common/header/index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
