### PR TITLE
Upcoming event text updates on Home Page

### DIFF
--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -18,7 +18,7 @@ class LowerMid extends Component {
 
   render() {
     const defaultContent =
-      "Check back again soon for what's is coming up next for YMIM. If you have an event that you think YMIM should be a part of please please email: Founder@theymim.org or call: 773.941.1200";
+      "Check back again soon for what's is coming up next for YMIM. If you have an event that you think YMIM should be a part of please email: Founder@theymim.org or call: 773.941.1200";
     const upcomingEvents = this.props.upcomingEvents;
     let nextEvent;
     if (upcomingEvents.length) {
@@ -119,4 +119,7 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(LowerMid);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(LowerMid);


### PR DESCRIPTION
### Issue:#192

### Describe the problem being solved:
- Upcoming event text updates on Home Page

### Impacted areas in the application: 
Before: 
<img width="763" alt="Screen Shot 2020-01-09 at 8 29 50 PM" src="https://user-images.githubusercontent.com/44477773/72120817-d1326e00-331e-11ea-8940-2752c9ccd9cc.png">

After: 
<img width="764" alt="Screen Shot 2020-01-09 at 8 30 57 PM" src="https://user-images.githubusercontent.com/44477773/72120877-faeb9500-331e-11ea-9d32-3a50075788bf.png">

List general components of the application that this PR will affect: 
* frontend/src/components/home/midsection/lower_mid.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
