### PR TITLE
Comma added before "please email..."

### DIFF
--- a/frontend/src/components/home/midsection/lower_mid.jsx
+++ b/frontend/src/components/home/midsection/lower_mid.jsx
@@ -18,7 +18,7 @@ class LowerMid extends Component {
 
   render() {
     const defaultContent =
-      "Check back again soon for what is coming up next for YMIM. If you have an event that you think YMIM should be a part of please email: Founder@theymim.org or call: 773.941.1200";
+      "Check back again soon for what is coming up next for YMIM. If you have an event that you think YMIM should be a part of, please email: Founder@theymim.org or call: 773.941.1200";
     const upcomingEvents = this.props.upcomingEvents;
     let nextEvent;
     if (upcomingEvents.length) {


### PR DESCRIPTION
### Issue:#192

### Describe the problem being solved:
- Comma added before "please email..."
### Impacted areas in the application: 
Before: 
<img width="1019" alt="Screen Shot 2020-01-13 at 6 52 24 PM" src="https://user-images.githubusercontent.com/44477773/72304358-f59b8c80-3635-11ea-8f91-3a73ee0c9342.png">

After:
<img width="1006" alt="Screen Shot 2020-01-13 at 6 51 40 PM" src="https://user-images.githubusercontent.com/44477773/72304294-c127d080-3635-11ea-81cb-c3936d060a88.png">

List general components of the application that this PR will affect: 
* frontend/src/components/home/midsection/lower_mid.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
