### PR TITLE
Changed Footer- Copyright Year to being dynamic

### DIFF
--- a/frontend/src/components/common/footer/index.jsx
+++ b/frontend/src/components/common/footer/index.jsx
@@ -68,7 +68,7 @@ export default class footer extends Component {
               <div className="footer_text">
                 <Row className="justify-content-md-center contact">
                   <Col xs="12" sm="12" md="4" lg="4" xl="2">
-                    Copyright 2019
+                    Copyright {new Date().getFullYear()}
                   </Col>
                   <Col xs="12" sm="12" md="4" lg="4" xl="2">
                     <a className="contact" href="mailto:founder@theymim.org">


### PR DESCRIPTION
### Issue:#407

### Describe the problem being solved:
Changed Copyright Year on the Footer component to be dynamic
### Impacted areas in the application: 
Before: 
<img width="686" alt="Screen Shot 2020-01-29 at 12 34 03 PM" src="https://user-images.githubusercontent.com/44477773/73385947-a8edbd80-4293-11ea-9e4e-35b1bdd7233d.png">
After: 
<img width="689" alt="Screen Shot 2020-01-29 at 12 32 44 PM" src="https://user-images.githubusercontent.com/44477773/73385865-80fe5a00-4293-11ea-8391-e78ec235efd0.png">

List general components of the application that this PR will affect: 
* frontend/src/components/common/footer/index.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
