### PR TITLE
fix about page white space

### DIFF
--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -2,10 +2,10 @@
   padding-left: 133px;
   padding-right: 133px;
   display: block;
+}
 
-  .sub-heading {
-    font-size: 24px;
-  }
+.sub-heading {
+  font-size: 24px;
 }
 
 .about-people-row {
@@ -50,21 +50,24 @@
   margin-top: 45px;
   font-size: 48px;
   font-weight: bold;
+  display: inline-block;
 }
 
 /* tablet */
 
-@media all and (min-width: 426px) and (max-width: 1023px) {
+@media all and (min-width: 768px) and (max-width: 1023px) {
   #aboutPageTextRow {
     padding-left: 20px;
     padding-right: 20px;
-
-    .sub-heading {
-      font-size: 24px;
-    }
+  }
+  .sub-heading {
+    font-size: 24px;
   }
 
   #kim-image {
+    margin-top: 20px;
+  }
+  #pierre-image {
     margin-top: 20px;
   }
 
@@ -87,8 +90,29 @@
     font-size: 16px;
   }
   .about-heading {
-    font-size: 32px;
+    font-size: 45px;
     margin-left: 0;
+    text-align: center;
+  }
+  .people-col {
+    display: inline-block;
+    margin-left: 20px;
+  }
+  .people-heading {
+    font-size: 40px;
+    margin-top: 20px;
+  }
+  .people-col .sub-heading {
+    padding-top: 7px;
+  }
+  .about-people-row {
+    margin: 0px;
+  }
+  #shirley {
+    margin: 40px 0px 30px 0px;
+  }
+  #pierre {
+    margin-top: 20px;
   }
 }
 

--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -65,10 +65,14 @@
   }
 
   #kim-image {
-    margin-top: 20px;
+    margin-top: 0px;
   }
   #pierre-image {
-    margin-top: 20px;
+    margin-top: 0px;
+  }
+
+  #shirley-image {
+    margin-top: 0px;
   }
 
   .images {
@@ -99,20 +103,14 @@
     margin-left: 20px;
   }
   .people-heading {
-    font-size: 40px;
-    margin-top: 20px;
+    font-size: 38px;
+    margin-top: 0px;
   }
   .people-col .sub-heading {
     padding-top: 7px;
   }
   .about-people-row {
-    margin: 0px;
-  }
-  #shirley {
-    margin: 40px 0px 30px 0px;
-  }
-  #pierre {
-    margin-top: 20px;
+    margin: 20px 0px;
   }
 }
 

--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -10,11 +10,11 @@ class About extends Component {
   render() {
     return (
       <Container fluid="true">
-      <SingleCarousel
-        className="carousel"
-        header="Young Masterbuilders in Motion"
-        image="ymim6.png"
-      />
+        <SingleCarousel
+          className="carousel"
+          header="Young Masterbuilders in Motion"
+          image="ymim6.png"
+        />
         <Container>
           <Row id="aboutPageTextRow">
             <h1 className="heading"> About </h1>
@@ -84,10 +84,10 @@ class About extends Component {
           </Row>
           <h1 className="about-heading">Our People</h1>
           <Row className="about-people-row">
-            <Col xs="12" md="6" lg="4" xl="4" className="images">
+            <Col xs="12" md="5" lg="4" xl="4" className="images">
               <img id="kim-image" src={KimWright} alt={"Kim Wright"} />
             </Col>
-            <Col xs="12" md="6" lg="4" xl="6">
+            <Col xs="12" md="6" lg="4" xl="6" className="people-col">
               <h1 className="people-heading text-left">Kim Wright, MBA</h1>
               <h4 className="sub-heading text-left">Founder and President</h4>
               <p className="text-left">
@@ -110,15 +110,15 @@ class About extends Component {
             </Col>
           </Row>
 
-          <Row className="about-people-row">
-            <Col xs="12" md="6" lg="4" xl="4" className="images">
+          <Row className="about-people-row" id="pierre">
+            <Col xs="12" md="5" lg="4" xl="4" className="images">
               <img
                 id="pierre-image"
                 src={PierrePriestley}
                 alt={"Pierre Priestley"}
               />
             </Col>
-            <Col xs="12" md="6" lg="4" xl="6">
+            <Col xs="12" md="6" lg="4" xl="6" className="people-col">
               <h1 className="people-heading text-left">Pierre Priestley</h1>
               <h4 className="sub-heading text-left">
                 Board Officer, Treasurer
@@ -138,15 +138,15 @@ class About extends Component {
             </Col>
           </Row>
 
-          <Row className="about-people-row">
-            <Col xs="12" md="6" lg="4" xl="4" className="images">
+          <Row className="about-people-row" id="shirley">
+            <Col xs="12" md="5" lg="4" xl="4" className="images">
               <img
                 id="shirley-image"
                 src={ShirleyScott}
                 alt={"Shirley Scott"}
               />
             </Col>
-            <Col xs="12" md="6" lg="4" xl="6">
+            <Col xs="12" md="6" lg="4" xl="6" className="people-col">
               <h1 className="people-heading text-left">
                 Shirley Scott, MS, RN-BC, C-EFM, APN, DNP
               </h1>

--- a/frontend/src/components/static_pages/about.jsx
+++ b/frontend/src/components/static_pages/about.jsx
@@ -110,7 +110,7 @@ class About extends Component {
             </Col>
           </Row>
 
-          <Row className="about-people-row" id="pierre">
+          <Row className="about-people-row">
             <Col xs="12" md="5" lg="4" xl="4" className="images">
               <img
                 id="pierre-image"


### PR DESCRIPTION
### Issue:#403

### Describe the problem being solved:
Center the "Our People" section so the white space is more even on both right and left margins on all tablet views.
### Impacted areas in the application: 
BEFORE:
![Screenshot from 2020-01-27 20-05-05](https://user-images.githubusercontent.com/54036633/73411221-2c2a0600-42ca-11ea-8d8d-c5a79e1c4866.png)

AFTER: 
![Screenshot from 2020-01-29 18-53-48](https://user-images.githubusercontent.com/54036633/73411286-6dbab100-42ca-11ea-9ae5-32e3bd1259e6.png)

List general components of the application that this PR will affect: 
* frontend/src/components/static_pages/about.jsx
* frontend/src/components/static_pages/about.css 

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
