### PR TITLE
Decreased White Spacing For Enroll/Contact/Volunteer Pages For All Views

### DIFF
--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -12,7 +12,7 @@ class Enroll extends Component {
     this.state = {
       text: null,
       loadCounter: 0,
-      iframeHeight: 1300
+      iframeHeight: 1400
     };
   }
 
@@ -24,9 +24,23 @@ class Enroll extends Component {
       });
   }
 
+  setHeight = () => {
+    let width = window.innerWidth;
+    if (320 >= width && width < 375) {
+      return 1450;
+    } else if (375 >= width && width < 424) {
+      return 1400;
+    } else if (425 >= width && width < 767) {
+      return 1350;
+    } else if (768 >= width && width < 1024) {
+      return 1330;
+    } else {
+      return 1327;
+    }
+  };
+
   loaded = () => {
-    let height =
-      this.state.loadCounter % 2 === 0 ? this.state.iframeHeight + "px" : 400;
+    let height = this.state.loadCounter % 2 === 0 ? this.setHeight() : 400;
     let loadCounter = this.state.loadCounter + 1;
     this.setState({ iframeHeight: height, loadCounter: loadCounter });
   };

--- a/frontend/src/components/static_pages/contact.jsx
+++ b/frontend/src/components/static_pages/contact.jsx
@@ -9,11 +9,28 @@ class Contact extends Component {
     iframeHeight: 1100
   };
 
+  setHeight = () => {
+    let width = window.innerWidth;
+    if (320 >= width && width < 375) {
+      return 1300;
+    } else if (375 >= width && width < 424) {
+      return 1250;
+    } else if (425 >= width && width < 767) {
+      return 1205;
+    } else if (768 >= width && width <= 1024) {
+      return 1130;
+    } else {
+      return 1100;
+    }
+  };
+
   loaded = () => {
-    let height =
-      this.state.loadCounter % 2 === 0 ? this.state.iframeHeight : 400;
+    let height = this.state.loadCounter % 2 === 0 ? this.setHeight() : 400;
     let loadCounter = this.state.loadCounter + 1;
-    this.setState({ iframeHeight: height, loadCounter: loadCounter });
+    this.setState({
+      iframeHeight: height,
+      loadCounter: this.state.loadCounter + 1
+    });
   };
 
   render() {

--- a/frontend/src/components/volunteer/volunteer.jsx
+++ b/frontend/src/components/volunteer/volunteer.jsx
@@ -9,13 +9,17 @@ class Volunteer extends Component {
 
     this.state = {
       loadCounter: 0,
-      iframeHeight: 1250
+      iframeHeight: 1240
     };
   }
 
+  setHeight = () => {
+    let width = window.innerWidth;
+    return 320 >= width && width <= 647 ? 1300 : 1240;
+  };
+
   loaded = () => {
-    let height =
-      this.state.loadCounter % 2 === 0 ? this.state.iframeHeight + "px" : 400;
+    let height = this.state.loadCounter % 2 === 0 ? this.setHeight() : 400;
     this.setState({
       iframeHeight: height,
       loadCounter: this.state.loadCounter + 1


### PR DESCRIPTION
### Issue:

### Describe the problem being solved:
Decreased white spacing for all three pages that contain google forms, on all views, and also fixed the scrolling on mobile view. 

### Impacted areas in the application: 
Enroll Page Before:
<img width="616" alt="Screen Shot 2020-01-30 at 8 49 07 PM" src="https://user-images.githubusercontent.com/44908424/73508648-36b7ce80-43a2-11ea-9af6-61924351e469.png">

Enroll Page After:
<img width="615" alt="Screen Shot 2020-01-30 at 8 46 10 PM" src="https://user-images.githubusercontent.com/44908424/73508618-243d9500-43a2-11ea-8817-683f0d422701.png">

Volunteer Page Before:
<img width="615" alt="Screen Shot 2020-01-30 at 8 48 13 PM" src="https://user-images.githubusercontent.com/44908424/73508740-839ba500-43a2-11ea-9571-ef8241915d09.png">

Volunteer Page After:
<img width="621" alt="Screen Shot 2020-01-30 at 8 46 59 PM" src="https://user-images.githubusercontent.com/44908424/73508715-7088d500-43a2-11ea-864d-3c8f75665409.png">

Contact Page Before:
<img width="643" alt="Screen Shot 2020-01-30 at 8 47 53 PM" src="https://user-images.githubusercontent.com/44908424/73508724-78e11000-43a2-11ea-9fe8-c80aa6751563.png">

Contact Page After:
<img width="600" alt="Screen Shot 2020-01-30 at 8 45 41 PM" src="https://user-images.githubusercontent.com/44908424/73508785-a4fc9100-43a2-11ea-96d7-273018f126cc.png">

List general components of the application that this PR will affect: 
* frontend/src/components/enroll/index.jsx
* frontend/src/components/static_pages/contact.jsx
* frontend/src/components/volunteer/volunteer.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
