### PR TITLE
Decreased Whitespace on Enroll Page Above Text "Enroll Now"

### DIFF
--- a/frontend/src/components/enroll/index.jsx
+++ b/frontend/src/components/enroll/index.jsx
@@ -53,7 +53,7 @@ class Enroll extends Component {
           image="ymim7.png"
         />
         <div className="container group mt-2">
-          <div className="container col-sm-4 float-right mt-5">
+          <div className="container col-sm-4 float-right mt-4">
             <Markdown
               id="fontcss"
               className="text-left"


### PR DESCRIPTION
### Issue: #400 

### Describe the problem being solved:
There was a lot of spacing above "Enroll Now" for all views. 

### Impacted areas in the application: 
Before: 
<img width="767" alt="Screen Shot 2020-02-06 at 7 15 18 PM" src="https://user-images.githubusercontent.com/44908424/73992518-12657000-4915-11ea-80b9-3cf7c428dd9d.png">

After: 
<img width="751" alt="Screen Shot 2020-02-06 at 7 15 36 PM" src="https://user-images.githubusercontent.com/44908424/73992524-142f3380-4915-11ea-8089-05eb9e27694a.png">

List general components of the application that this PR will affect: 
* frontend/src/components/enroll/index.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [ ] I have run the [prettier](https://prettier.io/) command `make pretty`
