### PR TITLE
Fixed about page white space and "Our People" got left justify and bios got vertically center

### DIFF
--- a/frontend/src/components/static_pages/about.css
+++ b/frontend/src/components/static_pages/about.css
@@ -26,11 +26,10 @@
 }
 
 .about-heading {
-  margin: auto;
   font-size: 48px;
   font-weight: bold;
   width: 100%;
-  text-align: center;
+  padding-top: 20px;
 }
 
 .people-heading {
@@ -38,6 +37,12 @@
   font-weight: bold;
   display: inline-block;
   width: 100%;
+}
+
+.people-col {
+  display: block;
+  margin-bottom: auto;
+  margin-top: auto;
 }
 
 @media (min-width: 2000px) {
@@ -50,14 +55,6 @@
     margin-bottom: 10px;
   }
 
-  .images {
-    display: inline-block;
-  }
-
-  .about-people-row {
-    margin: 80px 0px;
-    text-align: center;
-  }
   h1.heading,
   h1.about-heading {
     font-size: 80px;
@@ -68,6 +65,9 @@
   }
   .people-heading {
     font-size: 64px;
+  }
+  .about-heading {
+    padding-top: 50px;
   }
 }
 


### PR DESCRIPTION

### Issue: #403 

### Describe the problem being solved:
* "Our People" needs to get left justify and added top padding to add spacing 
*  The bios of each person got vertically center
### Impacted areas in the application: 
* /frontend/src/components/static_pages/about.css
List general components of the application that this PR will affect: 
* Before:
![image](https://user-images.githubusercontent.com/54036633/75204848-addd4a00-5737-11ea-81ce-e9844895125a.png)

![image](https://user-images.githubusercontent.com/54036633/75204820-9736f300-5737-11ea-909b-4ae1f9ae12d8.png)

* After:
![image](https://user-images.githubusercontent.com/54036633/75204719-46bf9580-5737-11ea-9114-9c657f3a34d2.png)
![image](https://user-images.githubusercontent.com/54036633/75204785-7a022480-5737-11ea-8595-8022e90d40ad.png)

PR checklist
- [X] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
