### PR TITLE
Resources Menu 

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -32,7 +32,8 @@
   height: 100%;
   padding: 20px 80px 20px 8px;
   color: white !important;
-  padding-bottom: 45px;
+  margin-left: -25px;
+  margin-right: 30px;
 }
 
 .resources-link:hover {
@@ -142,6 +143,9 @@ a.dropdown-item {
     padding-left: 296px;
     color: white;
   }
+  .resources-link {
+    margin-left: -3px;
+  }
 }
 
 @media all and (min-width: 320px) and (max-width: 768px) {
@@ -190,6 +194,7 @@ a.dropdown-item {
 
   .resources-link {
     padding: 0px 8px;
+    margin-left: 5px;
   }
 
   .align-links {

--- a/frontend/src/components/common/header/navbar.jsx
+++ b/frontend/src/components/common/header/navbar.jsx
@@ -71,14 +71,14 @@ class NavBar extends Component {
               <Navbar.Collapse>
                 <Nav className="ml-lg-3 ml-xl-3 ml-auto mr-auto my-auto align-links">
                   {/* resources  */}
-                  <Nav.Link
+                  <NavLink
                     className="resources-link"
-                    href={this.props.resources}
+                    to={this.props.resources}
                     download
                     target="_blank"
                   >
                     Resources
-                  </Nav.Link>
+                  </NavLink>
                   {/* enroll  */}
                   <NavLink className="resources-link" to="/enrollment">
                     Enroll
@@ -123,7 +123,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NavBar);
+export default connect(mapStateToProps, mapDispatchToProps)(NavBar);


### PR DESCRIPTION
### Issue:#440

### Describe the problem being solved:
- moved resources menu to the left on nav bar 
- aligned resources menu with the volunteer and enroll in the hamburger menu

### Impacted areas in the application: 
Before:
<img width="408" alt="Screen Shot 2020-04-01 at 8 43 15 PM" src="https://user-images.githubusercontent.com/44477773/78202314-9c374280-7459-11ea-85a4-30fc689c2a53.png">
<img width="641" alt="Screen Shot 2020-04-01 at 8 43 51 PM" src="https://user-images.githubusercontent.com/44477773/78202320-9fcac980-7459-11ea-82b2-d824be8583b9.png">
<img width="641" alt="Screen Shot 2020-04-01 at 8 43 58 PM" src="https://user-images.githubusercontent.com/44477773/78202326-a35e5080-7459-11ea-9d02-2bfcdb79ca42.png">

After:
<img width="431" alt="Screen Shot 2020-04-01 at 8 37 54 PM" src="https://user-images.githubusercontent.com/44477773/78202168-30ed7080-7459-11ea-86b7-1d587e0c3aeb.png">
<img width="517" alt="Screen Shot 2020-04-01 at 8 40 27 PM" src="https://user-images.githubusercontent.com/44477773/78202169-334fca80-7459-11ea-950e-b7535be8221f.png">
<img width="622" alt="Screen Shot 2020-04-01 at 8 40 40 PM" src="https://user-images.githubusercontent.com/44477773/78202181-377be800-7459-11ea-937e-9b68bd29de06.png">
<img width="622" alt="Screen Shot 2020-04-01 at 8 40 51 PM" src="https://user-images.githubusercontent.com/44477773/78202190-3a76d880-7459-11ea-8a08-dfa2f1ee22f0.png">
<img width="758" alt="Screen Shot 2020-04-01 at 8 41 13 PM" src="https://user-images.githubusercontent.com/44477773/78202192-3d71c900-7459-11ea-9cf3-04ebeeb3e147.png">


List general components of the application that this PR will affect: 
* frontend/src/components/common/header/index.css
* frontend/src/components/common/header/navbar.jsx

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
