### PR TITLE
Removing the hover of the Resources link

### DIFF
--- a/frontend/src/components/common/header/index.css
+++ b/frontend/src/components/common/header/index.css
@@ -41,11 +41,6 @@
   color: #fdd368 !important;
 }
 
-#resource-inactive:hover {
-  text-decoration: none;
-  color: #fdd368 !important;
-}
-
 #resource-inactive {
   color: white !important;
 }


### PR DESCRIPTION
### Issue:#440

### Describe the problem being solved:
*  Remove the hover of the Resouces link, it should stay white at all times.
### Impacted areas in the application: 
Before: 
![image](https://user-images.githubusercontent.com/54036633/78596769-f3e6fc80-7811-11ea-9c47-33403fff34fc.png)
After:
![image](https://user-images.githubusercontent.com/54036633/78596888-242e9b00-7812-11ea-8c58-85e96aafc25e.png)

List general components of the application that this PR will affect: 
* frontend\src\components\common\header\index.css

PR checklist
- [x] I included  a screenshot for FE changes
- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
- [-] I have run the [prettier](https://prettier.io/) command `make pretty`
